### PR TITLE
Fix/176 prevent scroll to item from overlapping other content

### DIFF
--- a/src/client/pages/_locale/cases/_slug.vue
+++ b/src/client/pages/_locale/cases/_slug.vue
@@ -178,6 +178,7 @@
 
   .page-case__scroll-to {
     grid-row: 1;
+    grid-column: 2;
     position: relative;
     margin-top: var(--spacing-big);
   }


### PR DESCRIPTION
This pull-request includes:

- Gives a scroll to item a width to prevent it from overlapping other content in the case page header