### PR TITLE
refactor(blog): rename link to link_section in blog content

### DIFF
--- a/src/client/pages/_locale/blog/_slug.query.graphql
+++ b/src/client/pages/_locale/blog/_slug.query.graphql
@@ -66,7 +66,7 @@ fragment page on BlogPostRecord {
         inverse
       }
     },
-    ... on LinkRecord {
+    ... on LinkSectionRecord {
     	link,
       label,
       external,

--- a/src/client/pages/_locale/blog/_slug.vue
+++ b/src/client/pages/_locale/blog/_slug.vue
@@ -64,7 +64,7 @@
           large-text />
 
         <div
-          v-if="item.__typename === 'LinkRecord'"
+          v-if="item.__typename === 'LinkSectionRecord'"
           :key="item.link">
           <app-button
             class="page-blog-post__button"


### PR DESCRIPTION
renamed modular content in blog post to link_section so that I am free to add a new Link model.