### PR TITLE
feat(blog-post): added extra margin on responsive video comp on blog …

### DIFF
--- a/src/client/components/responsive-video/responsive-video.vue
+++ b/src/client/components/responsive-video/responsive-video.vue
@@ -180,6 +180,8 @@
   @media (min-width: 1440px) {
     .responsive-video {
       width: 1440px;
+      margin-left: auto;
+      margin-right: auto;
     }
   }
 </style>


### PR DESCRIPTION
 added extra spacing below responsive video on larger screen on blog post pages

Testable by visiting pages where video component is used on blogposts: https://deploy-preview-251--voorhoede-dragonfly.netlify.com/nl/blog/javascript-frameworks-meet-web-components/

It seemed to happen on large screen sizes: 1440px+

