### PR TITLE
fix: always redirect to locale with 303

### DIFF
--- a/dato.config.js
+++ b/dato.config.js
@@ -120,8 +120,8 @@ function errorPageToJson(errorPage) {
 function redirectsToText (redirects, locales, defaultLocale) {
   const redirectsToNonDefaultLocales = locales
     .filter(locale => locale !== defaultLocale)
-    .map(locale => `/ /${locale}/ 303 Language=${locale}`)
-  const redirectToDefaultLocale = `/ /${defaultLocale}/ 303`
+    .map(locale => `/ /${locale}/ 302 Language=${locale}`)
+  const redirectToDefaultLocale = `/ /${defaultLocale}/ 302`
 
   const redirectRulesFromCms = redirects
     .map(redirect => `${redirect.from} ${redirect.to} ${redirect.httpStatusCode}`)


### PR DESCRIPTION
Right now the redirect from `/` to `/nl/` is cached. This shouldn't be the case. Besides, according to Thadee, we should be using 303's in this use case