### PR TITLE
chore/405--improve-build-performance-during-development

### DIFF
--- a/src/client/lib/prismify-code-blocks.js
+++ b/src/client/lib/prismify-code-blocks.js
@@ -7,6 +7,7 @@ const Prism = require('prismjs')
  * The required languages here will also be highlighted in development.
  */
 require('prismjs/components/prism-bash')
+require('prismjs/components/prism-wasm')
 
 module.exports = function prismifyCodeBlocks(items) {
   items.forEach(item => {


### PR DESCRIPTION
For syntax highlighting, non standard prism languages were required with a dynamic path inside a require statement. This caused webpack to have really poor build performance in development. Prismjs is included in the development build, with code blocks coming from the graphql endpoint of dato. Therefore webpack doesn't know which languages should be required and just required them all.

I rebuild this to always require `bash` and `wasm`, besides the standard languages (`html, markdown, css, js`). Right now we're only using bash of these two, but I can imagine we might write a blog post using `wasm` in the future. Other languages will still be highlighted in production builds, but not in development builds.

I also tried to do require missing languages when a `HIGHLIGHT_SYNTAX` node env was present, but then the build performance in development somehow still was miserable (twice as slow).