### PR TITLE
fix/403--app-header-too-small

### DIFF
--- a/src/client/components/app-header/app-header.vue
+++ b/src/client/components/app-header/app-header.vue
@@ -187,7 +187,7 @@
     color: var(--html-blue);
   }
 
-  @media screen and (min-width: 720px) {
+  @media screen and (min-width: 800px) {
     .app-header__logo {
       height: 1.875rem; /* 30px */
     }

--- a/src/client/components/app-mobile-menu/app-mobile-menu.vue
+++ b/src/client/components/app-mobile-menu/app-mobile-menu.vue
@@ -24,7 +24,7 @@
           alt="">
       </nuxt-link>
       <ul class="app-mobile-menu__list body-petite">
-        <li 
+        <li
           class="app-mobile-menu__list-item">
           <nuxt-link
             class="h3"
@@ -53,7 +53,7 @@
       @touchmove="prevent"
       :aria-label="$t('close_menu')"
     >
-      <div 
+      <div
         class="app-mobile-menu__button-icon app-mobile-menu__button-icon--close">
       </div>
     </button>
@@ -189,7 +189,7 @@
     }
   }
 
-  @media screen and (min-width: 720px) {
+  @media screen and (min-width: 800px) {
     .app-mobile-menu {
       display: none;
     }


### PR DESCRIPTION
The links app-header were rendered on a too small breakpoint, causing ugly wrapping.