### PR TITLE
fix/grid-chrome-80

### DIFF
--- a/src/client/components/app-core/grid.css
+++ b/src/client/components/app-core/grid.css
@@ -2,17 +2,30 @@
 .grid {
   display: grid;
   grid-template-columns:
-    var(--grid-margin)                          /* 1  2        */
-    var(--grid-column-small) 1fr repeat(8, 0)   /* 2  3   4-12 */
-    var(--grid-column-small) 1fr repeat(8, 0)   /* 12 13 14-22 */
-    var(--grid-column-small) 1fr                /* 22 23 24    */
-    var(--grid-column-small) .5fr               /* 24 25 26    */
+    var(--grid-margin)                                     /* 1  2        */
+    var(--grid-column-small) 1fr repeat(8, 0)              /* 2  3   4-12 */
+    var(--grid-column-small) 1fr repeat(8, 0)              /* 12 13 14-22 */
+    var(--grid-column-small) 1fr                           /* 22 23 24    */
+    var(--grid-column-small) 1px                           /* 24 25 26    */
     /* center */
-    .5fr var(--grid-column-small)               /* 26 27 28    */
-    1fr var(--grid-column-small) repeat(8, 0)   /* 28 29 30-38 */
-    1fr var(--grid-column-small) repeat(8, 0)   /* 38 39 40-48 */
-    1fr var(--grid-column-small)                /* 48 49 50    */
-    var(--grid-margin)                          /* 50 51       */
+    1px var(--grid-column-small)                           /* 26 27 28    */
+    1fr var(--grid-column-small) repeat(8, 0)              /* 28 29 30-38 */
+    1fr var(--grid-column-small) repeat(8, 0)              /* 38 39 40-48 */
+    1fr var(--grid-column-small)                           /* 48 49 50    */
+    var(--grid-margin);                                    /* 50 51       */
+  
+  grid-template-columns:
+    var(--grid-margin)                                     /* 1  2        */
+    var(--grid-column-small) minmax(0, 1fr) repeat(8, 0)   /* 2  3   4-12 */
+    var(--grid-column-small) minmax(0, 1fr) repeat(8, 0)   /* 12 13 14-22 */
+    var(--grid-column-small) minmax(0, 1fr)                /* 22 23 24    */
+    var(--grid-column-small) 1px                           /* 24 25 26    */
+    /* center */
+    1px var(--grid-column-small)                           /* 26 27 28    */
+    minmax(0, 1fr) var(--grid-column-small) repeat(8, 0)   /* 28 29 30-38 */
+    minmax(0, 1fr) var(--grid-column-small) repeat(8, 0)   /* 38 39 40-48 */
+    minmax(0, 1fr) var(--grid-column-small)                /* 48 49 50    */
+    var(--grid-margin);                                    /* 50 51       */
 }
 
 .grid > * {


### PR DESCRIPTION
Right now the grid's getting stretched in chrome >80 on some blog pages with code blocks (https://www.voorhoede.nl/nl/blog/say-no-to-image-reflow/ for instance) on small devices.

This PR puts some band aid on that (see https://codepen.io/MadeByMike/full/LYVYXbv).