### PR TITLE
feat(blogpost): add linkedin sharing button

### DIFF
--- a/src/client/components/social-share-buttons/social-share-buttons.vue
+++ b/src/client/components/social-share-buttons/social-share-buttons.vue
@@ -64,6 +64,12 @@
             label: 'facebook',
             alt: 'Share this post on Facebook',
           },
+          {
+            icon: 'linkedin--blue',
+            href: `https://www.linkedin.com/shareArticle?&url=${this.url}&title=${this.title}`,
+            label: 'linkedin',
+            alt: 'Share this post on LinkedIn'
+          }
         ]
       },
     },


### PR DESCRIPTION
The environment on linkedin doesn't look that nice. Maybe there intent is to focus on mobile only? I've check with other websites (if they have the linkedin share option at all) and it looks te same 