### PR TITLE
Fix/case excerpt chrome mobile lazy load

### DIFF
--- a/src/client/components/case-excerpt/case-excerpt.vue
+++ b/src/client/components/case-excerpt/case-excerpt.vue
@@ -100,9 +100,12 @@
     z-index: var(--z-index-low);
   }
 
-  .case-excerpt__image {
-    max-height: 100%;
-    max-width: 100%;
+  /**
+   * The responsive image requires height for the lazy load.
+   * Otherwise the intersection observer doesn't get triggered in chrome android.
+   */
+  .case-excerpt .responsive-image {
+    height: 100%;
   }
 
   .case-excerpt__title {


### PR DESCRIPTION
The image of the case excerpts (case page & home), didn't seem to work consistently on chrome mobile, caused by the lazy load having an height of `0px`. This bug can also be reproduced in chrome, by simulating an iPhone 6/7/8 in the responsive device mode.

Besides, I removed some legacy styling for a removed element.

Ticket: https://trello.com/c/2B9uiqfb/423-case-excerpt-illustrations-dont-load-in-android-chrome