### PR TITLE
case-excerpt: refactor hover state 

### DIFF
--- a/src/client/components/case-excerpt/case-excerpt.vue
+++ b/src/client/components/case-excerpt/case-excerpt.vue
@@ -83,10 +83,11 @@
   }
 
   /**
-   * The responsive image requires height for the lazy load.
+   * 1. The responsive image requires height for the lazy load.
    * Otherwise the intersection observer doesn't get triggered in chrome android.
+   * 2. nested in .case-excerpt for Safari to reliable handle the cascade
    */
-  .case-excerpt__image {
+  .case-excerpt .case-excerpt__image {
     height: var(--case-excerpt-image-height);
     background: var(--fog);
   }


### PR DESCRIPTION
refactor hover states for case-excerpt cards to use transforms instead of margin/position