### PR TITLE
fix mobile menu top position

### DIFF
--- a/src/client/components/app-mobile-menu/app-mobile-menu.vue
+++ b/src/client/components/app-mobile-menu/app-mobile-menu.vue
@@ -165,6 +165,8 @@
     flex-direction: column;
     grid-column: var(--grid-page);
     position: fixed;
+    top: 0;
+    left: 0;
     height: 100vh;
     width: 100vw;
     background-color: var(--brand-yellow);


### PR DESCRIPTION
keep mobile menu fixed to top/left. the header-banner caused vertical offset on homepage. 