### PR TITLE
Fix/page header scroll indicator

### DIFF
--- a/src/client/components/app-core/variables.css
+++ b/src/client/components/app-core/variables.css
@@ -37,6 +37,7 @@
   /* COMPONENTS */
   --app-header-height-small: 3.125rem; /* 50px */
   --app-header-height-large: 4.0625rem; /* 65px */
+  --scroll-to-height: 150px;
 
   /* Z-INDEXES */
   --z-index-low: 1;

--- a/src/client/components/page-header/page-header.vue
+++ b/src/client/components/page-header/page-header.vue
@@ -229,7 +229,7 @@
 
   .page-header .scroll-to {
     position: absolute;
-    bottom: var(--spacing-medium);
+    top: calc(100vh - var(--spacing-medium) - var(--scroll-to-height));
     left: var(--grid-margin);
   }
 
@@ -331,6 +331,8 @@
 
     .page-header--fill-screen .scroll-to {
       left: 0;
+      top: auto;
+      bottom: var(--spacing-medium);
     }
 
     .page-header__text {

--- a/src/client/components/scroll-to/scroll-to.vue
+++ b/src/client/components/scroll-to/scroll-to.vue
@@ -50,7 +50,7 @@
     position: relative;
     z-index: var(--z-index-low);
     width: 32px;
-    height: 150px;
+    height: var(--scroll-to-height);
     user-select: none;
   }
 


### PR DESCRIPTION
The scroll indicator on mobile was positioned at the bottom of the page, caused by [`position: relative` on the layout]( https://github.com/voorhoede/voorhoede-dragonfly/commit/b3dc99d760db0bd1aeb1f291ac517184c0c988db#diff-fabff5f8eb2bb0786c7a9f42742a18eaR62).