### PR TITLE
Fix/resolve autoprefixer warning

### DIFF
--- a/src/client/pages/services/_slug.vue
+++ b/src/client/pages/services/_slug.vue
@@ -253,13 +253,13 @@
   }
 
   @media (min-width: 1100px) {
-    .page-service__series-navigation,
     .page-service__overview {
       grid-column-start: 4;
       grid-column-end: 48;
     }
 
     .page-service__series-navigation {
+      grid-column-start: 4;
       grid-column-end: 35;
     }
 


### PR DESCRIPTION
Autoprefixer can only prefix grid-column-end when grid-column-start is defined in the same declaration block.