### PR TITLE
feat(blog): saturate blog avatar images

### DIFF
--- a/src/client/components/blog-author/blog-author.vue
+++ b/src/client/components/blog-author/blog-author.vue
@@ -81,6 +81,10 @@
     display: none;
   }
 
+  .blog-author__image img {
+    object-position: 0 0;
+  }
+
   .blog-author__text-time {
     display: block;
     color: var(--dim);
@@ -91,6 +95,7 @@
       display: block;
       padding-right: var(--spacing-small);
       border-right: 2px solid var(--very-dim);
+      filter: saturate(0);
     }
 
     .blog-author__text {

--- a/src/client/components/blog-list-item/blog-list-item.vue
+++ b/src/client/components/blog-list-item/blog-list-item.vue
@@ -22,7 +22,7 @@
               <img
                 class="blog-list-item__image"
                 :class="{ 'blog-list-item__image--large': large }"
-                :src="`${author.image.url}?auto=compress&auto=quality&fm=jpeg&w=65&h=65&fit=crop`"
+                :src="`${author.image.url}?auto=compress&auto=quality&fm=jpeg&w=65&h=65`"
                 alt=""
               >
             </lazy-load>
@@ -137,7 +137,9 @@
 
   .blog-list-item__image {
     display: block;
-    object-fit: contain;
+    object-fit: cover;
+    object-position: 0 0;
+    filter: saturate(0);
     height: var(--blog-thumbnail-small);
     width: var(--blog-thumbnail-small);
     margin-right: var(--spacing-smaller);


### PR DESCRIPTION
Because i've added new images for the CTA image block in color. They need to be saturated for the blog pages.
And positioned correctly.

I've added a new ticket to the board to create an avatar field on the person object so we can have two photo's.