### PR TITLE
fix(cta-image-block): enforce overwriting responsive image styles

### DIFF
--- a/src/client/components/cta-image-block/cta-image-block.vue
+++ b/src/client/components/cta-image-block/cta-image-block.vue
@@ -3,7 +3,6 @@
     <responsive-image
       :width-step="120"
       :image="personImage"
-      class="cta-image-block__image"
       :alt="personName" />
 
     <div class="cta-image-block__content">
@@ -95,14 +94,14 @@
     margin-top: var(--spacing-small);
   }
 
-  .cta-image-block__image {
+  .cta-image-block .responsive-image {
     max-width: 135px;
     margin: var(--spacing-small) 0;
     z-index: 1;
   }
 
   @media (min-width: 600px) {
-    .cta-image-block__image {
+    .cta-image-block .responsive-image {
       margin: var(--spacing-medium) 0;
     }
   }


### PR DESCRIPTION
Can be tested on https://deploy-preview-418--voorhoede-dragonfly.netlify.app/nl/services/prototyping-sprint/ (vs https://www.voorhoede.nl/nl/services/prototyping-sprint/) in the last call to action.

Currently the `margin` definitions on the `responsive-image` are being overwritten by the `responsive-image` styles, as the selector specificity is the same. Therefore it's dependent on the order of the CSS, which cannot really be enforced with webpack...