### PR TITLE
Fix(seo-head): 'og:url' should be the same as the canonical.

### DIFF
--- a/src/client/lib/seo-head.js
+++ b/src/client/lib/seo-head.js
@@ -23,7 +23,7 @@ export default function () {
     meta: [
       { name: 'description', content: page.social.description },
       { name: 'keywords', content: page.keywords },
-      { property: 'og:url', content: `${baseUrl}/` },
+      { property: 'og:url', content: `${baseUrl}${this.$route.path}` },
       { property: 'og:type', content: 'website' },
       { property: 'og:title', content: pageTitle },
       { property: 'og:description', content: page.social.description },


### PR DESCRIPTION
Currently, our LinkedIn previews are not working because the `og:url` is pointing to the wrong URL. This PR should fix this issue.