### PR TITLE
Fix/aspect ratio on service page images

### DIFF
--- a/src/client/components/page-header/page-header.vue
+++ b/src/client/components/page-header/page-header.vue
@@ -328,7 +328,7 @@
     .page-header__image-column {
       grid-column: 29 / 49;
       grid-row: 3 / 5;
-      margin-bottom: calc(-1 * var(--spacing-small)); /* Make image move outside page header */
+      margin-bottom: var(--spacing-medium);
     }
 
     .page-header--fill-screen .page-header__image-column {


### PR DESCRIPTION
Fixen verhouding afbeeldingen servicepagina's ([TRELLO-pTqAOTwF](https://trello.com/c/pTqAOTwF))

**Main features**
- adjust all service svg's and prefixed them with `service-{name}` in dato so we can start using them for other cards to without losing the real source.
- removed margin at the bottom because not all pictures have a surface just like the hare.svg

**Dato CMS**
- There is no option to select a height as acceptance criteria only so made a description for it now

**Screenshots**
![image](https://user-images.githubusercontent.com/5878256/113307782-c9852d80-9305-11eb-805c-93789975c4e0.png)
![image](https://user-images.githubusercontent.com/5878256/113307797-d0ac3b80-9305-11eb-9d1c-3c1ff5eb8433.png)
