### PR TITLE
Fix/service links

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -87,7 +87,6 @@ module.exports = {
     middleware: [
       'meta-canonical',
     ],
-    trailingSlash: true,
   },
 
   plugins: [

--- a/src/client/pages/services/_slug.vue
+++ b/src/client/pages/services/_slug.vue
@@ -79,6 +79,7 @@
 
   import asyncPage from '~/lib/async-page'
   import head from '~/lib/seo-head'
+  import { enforceTrailingSlash } from '~/plugins/locale-urls'
 
   import {
     SET_PREVIOUS_SERVICE_TITLE,
@@ -107,8 +108,10 @@
           && data.page.breadcrumbsNextService
           && data.page.breadcrumbsNextService.slug === context.from.params.slug
         )
+        const services = context.app.localePath('services')
+        const servicesRoute = enforceTrailingSlash(services)
         const useFallbackBackRoute = !previousRouteIsServiceSlugPage || breadcrumbsNextServiceIsPreviousRoute
-        const backLinkRoute = useFallbackBackRoute ? context.app.localePath('services') : context.from
+        const backLinkRoute = useFallbackBackRoute ? servicesRoute : context.from
 
         return {
           ...data,

--- a/src/client/plugins/locale-urls.js
+++ b/src/client/plugins/locale-urls.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-const enforceTrailingSlash = url => (url.endsWith('/') ? url : `${url}/`)
+export const enforceTrailingSlash = url => (url.endsWith('/') ? url : `${url}/`)
 
 Vue.mixin({
   methods: {


### PR DESCRIPTION
Fix "terug naar alle services" link onderaan pagina ([TRELLO-YK4ENQ1w](https://trello.com/c/YK4ENQ1w))

**Main feature**
- add trailing slashes to all routes by default. This broken on some places in the deployed website with backbuttons.
- replace a with nuxtlink and localeUrl.
