### PR TITLE
Add width and height to images that miss them

### DIFF
--- a/src/client/components/app-footer/app-footer.vue
+++ b/src/client/components/app-footer/app-footer.vue
@@ -3,7 +3,7 @@
     <div class="app-footer__layout">
       <div class="app-footer__header">
         <nuxt-link :to="localeUrl('index')" :aria-label="$t('home')" :title="$t('home')">
-          <img class="app-footer__header-logo" src="/images/logo-with-text.svg" alt="">
+          <img class="app-footer__header-logo" src="/images/logo-with-text.svg" alt="" width="190" height="32">
         </nuxt-link>
       </div>
       <div class="app-footer__column">

--- a/src/client/components/app-header/app-header.vue
+++ b/src/client/components/app-header/app-header.vue
@@ -2,7 +2,7 @@
   <nav class="app-header grid" :aria-label="title">
     <div class="app-header__content">
       <nuxt-link class="app-header__home-link" :to="localeUrl('index')">
-        <img class="app-header__logo" src="/images/logo-with-text.svg" alt="Home">
+        <img class="app-header__logo" src="/images/logo-with-text.svg" alt="Home" width="190" height="32">
       </nuxt-link>
       <div class="app-header__link-lists body-petite">
         <ul class="app-header__link-list">

--- a/src/client/components/page-header/page-header.vue
+++ b/src/client/components/page-header/page-header.vue
@@ -50,7 +50,7 @@
 
     <div v-if="image" class="page-header__image-column animation__reveal">
       <div class="page-header__image-column-content animation__reveal-content">
-        <img class="page-header__image" :src="image.url" alt=""/>
+        <img class="page-header__image" :src="image.url" :width="image.width" :height="image.height" alt=""/>
       </div>
     </div>
 


### PR DESCRIPTION
Small improvement, add missing attributes:
![image](https://user-images.githubusercontent.com/5701149/115851382-2b2d4900-a427-11eb-959f-a4e2498b420a.png)

For the logo I used the width and height defined in the viewbox since it's all about the aspect ratio, the actual width/height is set by the CSS.