### PR TITLE
Fix/FAQ page

### DIFF
--- a/src/client/pages/faq/index.vue
+++ b/src/client/pages/faq/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="page-faq">
+  <main class="page-faq grid">
     <page-header
       heading="byline"
       :byline="page.title"
@@ -36,11 +36,12 @@
 
 <style>
   .page-faq .page-header {
-    margin-bottom: var(--spacing-large);
     grid-row: 1;
+    margin-bottom: var(--spacing-large);
   }
 
   .page-faq__overview {
+    grid-column: var(--grid-content);
     grid-row: 2;
   }
 
@@ -51,8 +52,8 @@
   .page-faq__overview .scroll-to {
     display: none;
     position: absolute;
-    bottom: var(--spacing-big);
     right: var(--spacing-larger);
+    bottom: var(--spacing-big);
   }
 
   .page-faq .newsletter-form {
@@ -60,15 +61,12 @@
   }
 
   @media (min-width: 720px) {
-    .page-faq {
-      background-color: var(--bg-pastel);
+    .page-faq .page-header {
+      margin-bottom: var(--spacing-big);
     }
 
     .page-faq__overview {
       position: relative;
-      grid-column: var(--grid-content);
-      background-color: var(--white);
-      padding: var(--spacing-large) var(--spacing-larger);
     }
 
     .page-faq__overview .scroll-to {
@@ -78,9 +76,8 @@
 
   @media (min-width: 1100px) {
     .page-faq__overview {
-      grid-column: var(--grid-content-narrow);
-      padding: var(--spacing-big) var(--spacing-bigger);
+      grid-column-end: 48;
+      grid-column-start: 4;
     }
   }
-
 </style>


### PR DESCRIPTION
This pull-request fixes the FAQ page layout size.

Currently, the FAQ page content width is broken, see [https://www.voorhoede.nl/nl/faq/](https://www.voorhoede.nl/nl/faq/). I've fixed it using some inspiration from the `services/_slug` page.

### Before
<img width="2168" alt="Schermafbeelding 2022-05-31 om 14 36 37" src="https://user-images.githubusercontent.com/12752012/171174785-9d9196aa-7132-4b74-b7db-45980d73c6f1.png">

### After
<img width="2168" alt="Schermafbeelding 2022-05-31 om 14 36 48" src="https://user-images.githubusercontent.com/12752012/171174844-a0511756-2334-46a6-9a1c-bee896454a93.png">

