### PR TITLE
Feat/583-work-at-content-block

### DIFF
--- a/src/client/pages/work-at/index.query.graphql
+++ b/src/client/pages/work-at/index.query.graphql
@@ -48,6 +48,15 @@ fragment workat on WorkatRecord {
     height
     format
   }
+  endTitle
+  endBody(markdown: true)
+  endImage {
+    url
+    alt
+    width
+    height
+    format
+  }
   uspsTitle
   usps {
     title

--- a/src/client/pages/work-at/index.vue
+++ b/src/client/pages/work-at/index.vue
@@ -54,6 +54,23 @@
       />
     </div>
 
+    <!-- We had to combine the ImageWithText with
+      the RichTextBlock to get the desired 'custom' layout -->
+    <div class="image-with-text">
+      <responsive-image
+        :image="page.endImage"
+      />
+      <div class="image-with-text__body">
+        <h2 class="image-with-text__body-title h3">
+          {{ page.endTitle }}
+        </h2>
+        <rich-text-block
+          class="image-with-text__body-text generic-text-block__body"
+          :text="page.endBody"
+        />
+      </div>
+    </div>
+
     <p class="body-big font-html-blue page-work-at__layout rich-text" v-html="page.jobsAfter" />
 
     <image-grid


### PR DESCRIPTION
This pull request includes the addition of an extra content block on the 'Work at' page. I had to combine 2 components to get the desired result (see comment). For the naming of the fields in Dato I decided to keep them in line with the `start` and `middle` prefixes, so I prefixed the fields with `end`.

_**Note, real content needs to be added to Dato, do not merge before content is in place.**_