### PR TITLE
fix(image-url): remove query params from svg urls

### DIFF
--- a/src/client/lib/image-url.js
+++ b/src/client/lib/image-url.js
@@ -17,6 +17,7 @@ const defaults = {
  * @param {Object} [params]     - Imgix manipulation parameters, see https://docs.imgix.com/apis/url
  */
 const imageUrl = (imagePath, params) => {
+  if (!imagePath) return ''
   if (imagePath.endsWith('.svg')) {
     return imagePath
   }


### PR DESCRIPTION
resulted in incorrect images like
https://www.datocms-assets.com/6524/1619684366-ninja-robot-superhero.svg?auto=compress&auto=quality&auto=format&w=1000

Resolves #514