### PR TITLE
Fix hydration error on navigation away from `series-navigation`

### DIFF
--- a/src/components/series-navigation/series-navigation.vue
+++ b/src/components/series-navigation/series-navigation.vue
@@ -16,7 +16,7 @@
       >
         <app-link
           v-if="!isActive(childRoute.route)"
-          :to="!isActive(childRoute) && childRoute.route"
+          :to="childRoute.route"
           class="body-big"
           :class="{
             'series-navigation__link': !isActive(childRoute)


### PR DESCRIPTION
The active route check in the `to` prop resolves to `false` when
navigating away from a page that contains the `series-navigation`
component. In turn the `app-link` component throws an error trying to
resolve `false` as a route with `router.resolve`. The check is unneeded
because of the `v-if` above it.

Error logged in console on prod, navigate away from this page: https://www.voorhoede.nl/en/services/inventory-workshop/