### PR TITLE
Simplify contact page form

### DIFF
--- a/src/components/contact-page-form/contact-page-form.vue
+++ b/src/components/contact-page-form/contact-page-form.vue
@@ -1,98 +1,84 @@
 <template>
   <form
-    @submit.prevent="submit"
     method="POST"
-    :name="form['form-name']"
+    name="get-in-touch"
     :action="`/${$i18n.locale()}/contact/confirmation/`"
     class="contact-page-form__form"
     data-netlify="true"
     data-netlify-honeypot="url-page"
-    :novalidate="useCustomValidation"
   >
     <fieldset>
-      <legend
-        v-if="ariaLabelOrTitle"
-        class="sr-only"
-      >
-        {{ ariaLabelOrTitle }}
+      <legend class="sr-only">
+        {{ title }}
       </legend>
       <div class="contact-page-form__personal-details">
         <div class="contact-page-form__column">
           <input
             type="hidden"
             name="form-name"
-            :value="form['form-name']"
-          >
-          <input
-            type="text"
-            name="subject"
-            :value="form.name"
-            class="hidden"
+            value="get-in-touch"
           >
           <label class="sr-only">
             Don't fill this out if you're human:
             <input
-              v-model="form['url-page']"
               name="url-page"
               type="url"
             >
           </label>
-          <input-field
-            v-model="form.name"
-            id="name"
-            type="text"
-            @input="createEmailSubject"
-            :label="$t('my_name_is')"
-            :placeholder-label="$t('your_name')"
-            required
-            :validate="formIsValidated"
-            :reset-validation="resetValidation"
-            :validation-error-message="$t('name_is_required')"
-            class="body-small contact-page-form__input-field"
-          />
-          <input-field
-            v-model="form.business"
-            id="business"
-            type="text"
-            :label="$t('my_business_is')"
-            :placeholder-label="$t('company_name')"
-            class="body-small contact-page-form__input-field"
-          />
+          <label class="input-field contact-page-form__input-field body-small">
+            <span class="input-field__label">{{ $t('my_name_is') }}</span>
+            <input
+              name="name"
+              type="text"
+              :placeholder="$t('your_name')"
+              required
+              class="input-field__input body"
+            >
+          </label>
+          <label class="input-field contact-page-form__input-field body-small">
+            <span class="input-field__label">{{ $t('my_business_is') }}</span>
+            <input
+              name="business"
+              type="text"
+              :placeholder="$t('company_name')"
+              class="input-field__input body"
+            >
+          </label>
         </div>
 
         <div class="contact-page-form__column">
-          <input-field
-            v-model="form.email"
-            id="email"
-            type="email"
-            :label="$t('you_can_email_me_at')"
-            :placeholder-label="$t('email_address')"
-            required
-            :validate="formIsValidated"
-            :reset-validation="resetValidation"
-            :validation-error-message="emailValidationErrorMessage"
-            class="body-small contact-page-form__input-field"
-          />
-          <input-field
-            v-model="form.phone"
-            id="phone"
-            type="tel"
-            :label="$t('you_can_call_me_at')"
-            :placeholder-label="$t('phone_number')"
-            class="body-small contact-page-form__input-field"
-          />
+          <label class="input-field contact-page-form__input-field body-small">
+            <span class="input-field__label">{{ $t('you_can_email_me_at') }}</span>
+            <input
+              name="email"
+              type="email"
+              :placeholder="$t('email_address')"
+              required
+              class="input-field__input body"
+            >
+          </label>
+          <label class="input-field contact-page-form__input-field body-small">
+            <span class="input-field__label">{{ $t('you_can_call_me_at') }}</span>
+            <input
+              name="phone"
+              type="tel"
+              :placeholder="$t('phone_number')"
+              class="input-field__input body"
+            >
+          </label>
         </div>
       </div>
 
-      <input-field
-        textarea
-        v-model="form.explanation"
-        id="explanation"
-        type="text"
-        :label="$t('my_project_is')"
-        :placeholder-label="$t('project_description')"
-        class="body-small contact-page-form__input-field"
-      />
+      <label class="input-field contact-page-form__input-field body-small">
+        <span class="input-field__label">{{ $t('my_project_is') }}</span>
+        <textarea
+          name="explanation"
+          type="text"
+          :placeholder="$t('project_description')"
+          class="input-field__input body"
+          rows="4"
+        />
+      </label>
       <app-button
         @click="trackEvent()"
         class="contact-page-form__button"
@@ -104,67 +90,14 @@
 </template>
 
 <script>
-  import submitContactForm from '../../lib/submit-contact-form'
-
   export default {
     props: {
       title: {
         type: String,
-        required: false,
-        default: undefined
+        required: true,
       },
-      ariaLabel: {
-        type: String,
-        required: false,
-        default: undefined
-      },
-    },
-    data() {
-      return {
-        form: {
-          'form-name': 'get-in-touch',
-          name: '',
-          email: '',
-          phone: '',
-          business: '',
-          explanation: '',
-          subject: '',
-        },
-        formIsValidated: false,
-        resetValidation: false,
-        useCustomValidation: false,
-      }
-    },
-    computed: {
-      ariaLabelOrTitle () {
-        return this.ariaLabel || this.title
-      },
-      emailValidationErrorMessage() {
-        return this.form.email ? this.$t('provide_valid_email') : this.$t('email_is_required')
-      }
-    },
-    mounted() {
-      this.useCustomValidation = true
     },
     methods: {
-      createEmailSubject(name) {
-        this.form.subject = `${name} has sent a message`
-      },
-      submit(event) {
-        this.formIsValidated = true
-        if (!event.target.checkValidity()) {
-          this.resetValidation = true
-          this.$nextTick(() => {
-            this.resetValidation = false
-          })
-          return false
-        }
-        submitContactForm({
-          form: event.target,
-          router: this.$router,
-          localeUrl: this.$localeUrl,
-        })
-      },
       trackEvent () {
         useTrackEvent('Send Contact Form CP');
       },

--- a/src/pages/[language]/contact/index.vue
+++ b/src/pages/[language]/contact/index.vue
@@ -47,7 +47,7 @@
       <div class="page-contact__backdrop grid">
         <contact-page-form
           class="page-contact__form-body"
-          :aria-label="$t('lets_discuss')"
+          :title="$t('lets_discuss')"
         />
       </div>
     </div>

--- a/src/server/api/contact-form.post.ts
+++ b/src/server/api/contact-form.post.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler((event) => (
+  sendRedirect(event, "/en/", 302)
+));


### PR DESCRIPTION
The Post action to the success page actually returns an invalid language, tested with Nuxt build it makes the whole page fail because it's not a GET method.
https://oliverjam.es/articles/better-native-form-validation