### PR TITLE
Add person external links to teams/slug

### DIFF
--- a/src/pages/[language]/team/[slug]/index.person.graphql
+++ b/src/pages/[language]/team/[slug]/index.person.graphql
@@ -10,7 +10,6 @@ fragment person on PersonRecord {
   jobTitle
   lastName
   employmentStatus
-  twitterHandle
   slug
   biography
   image {

--- a/src/pages/[language]/team/[slug]/index.vue
+++ b/src/pages/[language]/team/[slug]/index.vue
@@ -20,16 +20,12 @@
           </p>
         </div>
 
-        <span v-if="person.twitterHandle" class="body-small page-team__social">
-          {{ person.twitterHandle }}
-        </span>
-
         <ul class="page-team__links">
           <li v-for="link in person.links" :key="link.title">
             <a
               :href="link.url"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               class="body-small page-team__link"
             >
               {{ link.title }}
@@ -141,19 +137,16 @@ useSeoHead({
     }
   }
 
-  .page-team__social {
-    margin-top: var(--spacing-small);
-    color: var(--off-black);
-  }
-
   .page-team__links {
     margin-top: var(--spacing-small);
     list-style: none;
   }
 
   .page-team__link {
+    display: inline-block;
     width: fit-content;
     padding-bottom: .15rem;
+    margin-bottom: 0.6rem;
     color: var(--html-blue);
     background: transparent linear-gradient(to top, transparent 1px, var(--html-blue) 1px, var(--html-blue) 2px, transparent 2px);
   }


### PR DESCRIPTION
[Trello card](https://trello.com/c/gjoPg1TG/613-author-page-option-to-add-link)

So far we were only using the `Link` model for internal links, even though it has an optional `url` field. 

If we wanted to use it in a generic way, it can be external or a page and we don't know, with [`createHref`](https://github.com/voorhoede/voorhoede-website/blob/main/src/lib/links.js#L11) it would break even though that same library says it's a [valid link](https://github.com/voorhoede/voorhoede-website/blob/main/src/lib/links.js#L1). Didn't fix it, because I ended up only retrieving external links and not using `app-link`.

But I'm not sure what approach you would take.

**After merging**
- [ ] Make all twitter handle links
- [x] Remove twitter handle field