### PR TITLE
Fix order of pivots on services/slug

### DIFF
--- a/src/pages/[language]/services/[slug]/index.vue
+++ b/src/pages/[language]/services/[slug]/index.vue
@@ -139,7 +139,6 @@
   .page-service__overview .generic-text-block,
   .page-service__overview .blockquote-block,
   .page-service__overview > .responsive-video {
-    grid-row: 4;
     margin: 0 0 var(--spacing-large) 0;
   }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/kafGXIJV/614-pivot-verschijnt-bovenaan-de-pagina-ipv-onderaan-de-pagina)

The [Headless CMS service](https://www.voorhoede.nl/en/services/headless-cms/) doesn't belong to a collection, so it's missing the `.page-service__series-navigation` part (I've asked Vera on the card to see if this is on purpose). This means there is only one part on top of `.page-service__overview` instead of the expected 2, but it's still set to [`grid-row: 3`](https://github.com/voorhoede/voorhoede-website/blob/main/src/pages/%5Blanguage%5D/services/%5Bslug%5D/index.vue#L130) causing the pivot to go first. By specifying the `grid-row` for the pivot we prevent that.

**After merge**
- [x] Tell Vera the pivot can be added back
