### PR TITLE
Fix to include link with hreflang also for current language

### DIFF
--- a/src/composables/useSeoHead.js
+++ b/src/composables/useSeoHead.js
@@ -32,7 +32,6 @@ export function useSeoHead({ slug, i18nSlugs, social }) {
     ],
     link: [
       ...$i18n.locales
-        .filter(({ code }) => $i18n.locale !== code)
         .map(({ code }) => ({
           rel: 'alternate',
           hreflang: code,


### PR DESCRIPTION
Was trying to find information to pick up this [card](https://trello.com/c/iw5V31Vz/610-indexering-canonical-instellen) and saw that we are not following Google requirements for the [`hreflang` links](https://developers.google.com/search/docs/specialty/international/localized-versions#html). Each page has to have a link for [**itself** and all other languages](https://developers.google.com/search/docs/specialty/international/localized-versions#all-method-guidelines).

Maybe that will help with the indexing? 