### PR TITLE
Translated team bio's

### DIFF
--- a/src/pages/[language]/team/[slug]/index.person.graphql
+++ b/src/pages/[language]/team/[slug]/index.person.graphql
@@ -1,5 +1,5 @@
-query TeamSlug($slug: String) {
-  person(filter: { slug: { eq: $slug } }) {
+query TeamSlug($slug: String, $locale: SiteLocale) {
+  person(filter: { slug: { eq: $slug } }, locale: $locale) {
     ...person
   }
 }

--- a/src/pages/[language]/team/[slug]/index.vue
+++ b/src/pages/[language]/team/[slug]/index.vue
@@ -79,7 +79,7 @@ const { data: { value: { person } } } = await useFetchContent({
   query: personQuery,
   variables: {
     slug: route.params.slug,
-    language: route.params.language,
+    locale: route.params.language,
   },
 })
 


### PR DESCRIPTION
Related ticket: https://trello.com/c/60v92u8F/626-dutch-bio-is-not-showing

## Changes

- Adds 'locale' variable to 'person' query
- Passes that locale to the content fetch function

en:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/11621275/222398425-0f804d5a-26fa-4340-9603-794370757f80.png">

nl:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/11621275/222398497-ec7b8d77-9a27-41ba-84d1-59674ad0f936.png">
