### PR TITLE
Update heading level class

### DIFF
--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -116,7 +116,6 @@
             v-if="item.title"
             class="page-blog-post-list__title h3 font-html-blue"
             :is="`h${item.headingLevel || '3'}`"
-            :class="`h${item.headingLevel || '3'}`"
             :id="slugify(item.title)"
           >
             {{ item.title }}


### PR DESCRIPTION
This is a leftover from my previous PR about heading levels. The generated class did not have any effect since it's overwritten by the "h3" class.

Also discussed with vera that we need to determine the sizes of the headings in the blogpost instead of just leaving it all one size.