### PR TITLE
Handle invalid language parameter and render 404 page

### DIFF
--- a/src/components/app-header/app-header.vue
+++ b/src/components/app-header/app-header.vue
@@ -44,7 +44,7 @@
             :key="code"
           >
             <span
-              v-if="code === $i18n.locale"
+              v-if="code === $i18n.locale()"
               aria-hidden="true"
               class="app-header__link-list-item app-header__link-list-item--highlighted"
             >

--- a/src/components/blog-author/blog-author.vue
+++ b/src/components/blog-author/blog-author.vue
@@ -73,7 +73,7 @@
       formattedDate() {
         return formatDate({
           date: this.item.date,
-          locale: this.$i18n.locale,
+          locale: this.$i18n.locale(),
           format: 'D MMMM YYYY'
         })
       },

--- a/src/components/blog-list-item/blog-list-item.vue
+++ b/src/components/blog-list-item/blog-list-item.vue
@@ -88,7 +88,7 @@
         return formatDate({
           date: this.item.date,
           format: 'D MMM YYYY',
-          locale: this.$i18n.locale
+          locale: this.$i18n.locale(),
         })
       },
     },

--- a/src/components/calendar-icon/calendar-icon.vue
+++ b/src/components/calendar-icon/calendar-icon.vue
@@ -49,7 +49,7 @@ export default {
     month () {
       return formatDate({
         date: this.dateObject,
-        locale: this.$i18n.locale,
+        locale: this.$i18n.locale(),
         format: 'MMM'
       })
     },

--- a/src/components/contact-form/contact-form.vue
+++ b/src/components/contact-form/contact-form.vue
@@ -46,7 +46,7 @@
       @submit.prevent="submit"
       method="POST"
       :name="form['form-name']"
-      :action="`/${$i18n.locale}/contact/confirmation/`"
+      :action="`/${$i18n.locale()}/contact/confirmation/`"
       class="contact-form__form"
       data-netlify="true"
       netlify-honeypot="magic-castle"

--- a/src/components/contact-page-form/contact-page-form.vue
+++ b/src/components/contact-page-form/contact-page-form.vue
@@ -3,7 +3,7 @@
     @submit.prevent="submit"
     method="POST"
     :name="form['form-name']"
-    :action="`/${$i18n.locale}/contact/confirmation/`"
+    :action="`/${$i18n.locale()}/contact/confirmation/`"
     class="contact-page-form__form"
     data-netlify="true"
     data-netlify-honeypot="url-page"

--- a/src/components/timeline-block/timeline-block.vue
+++ b/src/components/timeline-block/timeline-block.vue
@@ -46,7 +46,7 @@
       formattedDate (value) {
         return formatDate({
           date: value,
-          locale: this.$i18n.locale,
+          locale: this.$i18n.locale(),
           format: 'DD MMMM YYYY'
         })
       },

--- a/src/composables/useFetchContent.js
+++ b/src/composables/useFetchContent.js
@@ -58,7 +58,7 @@ export async function useFetchContent({ key = null, query, variables }) {
   // can not rely on this being a page content query if a 'custom' key is set
   if (!key && initialData.value.page === null) {
     console.error('no page data found for', route.path);
-    throw createError({ statusCode: 404 });
+    throw createError({ statusCode: 404, fatal: true });
   }
 
   return { data };

--- a/src/error.vue
+++ b/src/error.vue
@@ -17,15 +17,14 @@
 </template>
 
 <script setup>
+  const { $i18n } = useNuxtApp();
   import query from './error.query.graphql?raw';
-
-  const { params } = useRoute();
 
   const { data } = await useFetchContent({
     key: 'ErrorPage',
     query,
     variables: {
-      locale: params.language,
+      locale: $i18n.locale(),
     },
   });
 </script>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -43,6 +43,7 @@
 </template>
 
 <script setup>
+  const { $i18n } = useNuxtApp();
   import query from './default.query.graphql?raw';
   const { afterEach } = useRouter();
   const skipLink = ref(null);
@@ -57,13 +58,11 @@
     }
   });
 
-  const { params } = useRoute();
-
   const { data } = await useFetchContent({
-    key: `DefaultLayout${params.language}`,
+    key: `DefaultLayout${$i18n.locale()}`,
     query,
     variables: {
-      locale: params.language,
+      locale: $i18n.locale(),
     },
   });
 </script>

--- a/src/lib/links.js
+++ b/src/lib/links.js
@@ -13,9 +13,9 @@ export function createHref ($i18n, item) {
   const directory = getDirectoryByTypename(page.__typename)
 
   if (page.slug && page.__typename) {
-    return `/${$i18n.locale}/${directory}/${page.slug}/`
+    return `/${$i18n.locale()}/${directory}/${page.slug}/`
   } else if (page.slug) {
-    return `/${$i18n.locale}/${page.slug}/`
+    return `/${$i18n.locale()}/${page.slug}/`
   } else {
     return url
   }

--- a/src/middleware/validate-language.global.ts
+++ b/src/middleware/validate-language.global.ts
@@ -1,8 +1,7 @@
 export default defineNuxtRouteMiddleware((to, from) => {
   const { $i18n } = useNuxtApp();
-  console.info({to, from});
 
-  if (!$i18n.isValidLocale({ locale: to.params.language }) && from.path === to.path) {
+  if (!$i18n.isValidLocale({ locale: to.params.language })) {
     console.warn('abortNavigation');
     return abortNavigation({ statusCode: 404, fatal: true });
   }

--- a/src/middleware/validate-language.global.ts
+++ b/src/middleware/validate-language.global.ts
@@ -1,7 +1,9 @@
 export default defineNuxtRouteMiddleware((to, from) => {
   const { $i18n } = useNuxtApp();
+  console.info({to, from});
 
-  if (!$i18n.isValidLocale()) {
+  if (!$i18n.isValidLocale({ locale: to.params.language }) && from.path === to.path) {
+    console.warn('abortNavigation');
     return abortNavigation({ statusCode: 404 });
   }
 })

--- a/src/middleware/validate-language.global.ts
+++ b/src/middleware/validate-language.global.ts
@@ -4,7 +4,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
 
   if (!$i18n.isValidLocale({ locale: to.params.language }) && from.path === to.path) {
     console.warn('abortNavigation');
-    return abortNavigation({ statusCode: 404 });
+    return abortNavigation({ statusCode: 404, fatal: true });
   }
 })
 

--- a/src/middleware/validate-language.global.ts
+++ b/src/middleware/validate-language.global.ts
@@ -1,0 +1,10 @@
+export default defineNuxtRouteMiddleware((to, from) => {
+  if (process.client) return;
+
+  const { $i18n } = useNuxtApp();
+
+  if (!$i18n.isValidLocale()) {
+    return abortNavigation({ statusCode: 404 });
+  }
+})
+

--- a/src/middleware/validate-language.global.ts
+++ b/src/middleware/validate-language.global.ts
@@ -2,7 +2,6 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const { $i18n } = useNuxtApp();
 
   if (!$i18n.isValidLocale({ locale: to.params.language })) {
-    console.warn('abortNavigation');
     return abortNavigation({ statusCode: 404, fatal: true });
   }
 })

--- a/src/middleware/validate-language.global.ts
+++ b/src/middleware/validate-language.global.ts
@@ -1,6 +1,4 @@
 export default defineNuxtRouteMiddleware((to, from) => {
-  if (process.client) return;
-
   const { $i18n } = useNuxtApp();
 
   if (!$i18n.isValidLocale()) {

--- a/src/pages/[language]/energy-first/index.vue
+++ b/src/pages/[language]/energy-first/index.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="energy-first-container">
-    <div v-if="$i18n.locale === 'en'">
+    <div v-if="$i18n.locale() === 'en'">
       <div class="container container-large x-spaced-medium">
         <h1 class="h1">
           An energy efficient web
@@ -263,7 +263,7 @@
         </div>
       </article>
     </div>
-    <div v-if="$i18n.locale === 'nl'">
+    <div v-if="$i18n.locale() === 'nl'">
       <div class="container container-large x-spaced-medium">
         <h1 class="h1">
           Een energiezuinig web

--- a/src/pages/[language]/team/[slug]/index.vue
+++ b/src/pages/[language]/team/[slug]/index.vue
@@ -83,6 +83,10 @@ const { data: { value: { person } } } = await useFetchContent({
   },
 })
 
+if (!person) {
+  throw createError({ statusCode: 404, fatal: true });
+}
+
 const { data: blogs } = await useFetchContent({
   key: ['blogs', route.name, ...Object.values(route.params)].filter(Boolean).join('-'),
   query: blogPostsQuery,

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -7,8 +7,8 @@ const i18n = rosetta(messages);
 export default defineNuxtPlugin((nuxtApp) => {
   i18n.locale(nuxtApp._route.params.language);
 
-  function isValidLocale() {
-    return locales.find(({ code }) => code === nuxtApp._route.params.language);
+  function isValidLocale({ locale }) {
+    return locales.find(({ code }) => code === locale);
   }
 
   return {
@@ -18,7 +18,7 @@ export default defineNuxtPlugin((nuxtApp) => {
         locales,
         isValidLocale,
         locale: () => {
-          if (!isValidLocale()) {
+          if (!isValidLocale({ locale: nuxtApp._route.params.language })) {
             return "en";
           }
 

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -7,13 +7,25 @@ const i18n = rosetta(messages);
 export default defineNuxtPlugin((nuxtApp) => {
   i18n.locale(nuxtApp._route.params.language);
 
+  function isValidLocale() {
+    return locales.find(({ code }) => code === nuxtApp._route.params.language);
+  }
+
   return {
     provide: {
       t: i18n.t,
       i18n: {
-        locale: nuxtApp._route.params.language,
         locales,
+        isValidLocale,
+        locale: () => {
+          if (!isValidLocale()) {
+            return "en";
+          }
+
+          return nuxtApp._route.params.language;
+        },
       },
     },
   };
 });
+

--- a/src/plugins/localeUrl.ts
+++ b/src/plugins/localeUrl.ts
@@ -5,7 +5,7 @@ export default defineNuxtPlugin((nuxtApp) => {
         return {
           name: ['language', name].filter(Boolean).join('-'),
           params: {
-            language: nuxtApp._route.params.language || 'en',
+            language: nuxtApp.$i18n.locale(),
             ...params,
           },
         };


### PR DESCRIPTION
- https://trello.com/c/sWxbLyx0/632-404-doesnt-work-on-non-localised-url-voorhoedenl-bla-for-instance
- https://trello.com/c/uBk7dH5p/631-bug-cannot-navigate-from-a-404-page

**Production**
- /bla: 404 blank page
- /bla/bla: 404 page
- /en/bla: 404 page
- /en/services/bla: 404 empty layout
- /en/team/bla: 404 empty layout

This PR fixes the above pages to render a 404 page, it's not perfect as there is a flash an empty layout however it's atleast better than before. Also noticed that all pages don't render at all without JS which I think is a limitation of using `nuxt generate` when handling errors.

For layout and an error page without a language param the i18n method now has a fallback.