### PR TITLE
Lock screen when the mobile menu is open

### DIFF
--- a/src/components/app-core/utilities.css
+++ b/src/components/app-core/utilities.css
@@ -13,6 +13,10 @@
   display: none;
 }
 
+.scroll-lock {
+  overflow: hidden;
+}
+
 /*
  * Overwrite all transitions,
  * since user with reduced motion enabled find it really important

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -21,8 +21,8 @@
         <app-mobile-menu
           :links="[].concat(data.menu.links, data.menu.callToAction)"
           :is-open="mobileMenuIsOpen"
-          @open-menu="mobileMenuIsOpen = true"
-          @close-menu="mobileMenuIsOpen = false"
+          @open-menu="openMenu"
+          @close-menu="closeMenu"
         />
       </nav>
       <div
@@ -50,7 +50,7 @@
   const focusTrapMobileMenu = computed(() => mobileMenuIsOpen.value ? true : null);
 
   afterEach((from, to) => {
-    mobileMenuIsOpen.value = false;
+    closeMenu()
 
     if (from.path !== to.path) {
       skipLink.value.focus();
@@ -66,6 +66,16 @@
       locale: params.language,
     },
   });
+
+  function openMenu() {
+    mobileMenuIsOpen.value = true;
+    document.body.classList.add("scroll-lock")
+  }
+
+  function closeMenu() {
+    mobileMenuIsOpen.value = false;
+    document.body.classList.remove("scroll-lock")
+  }
 </script>
 
 <style>


### PR DESCRIPTION
Fixes #544 

I saw on some of the suggested solutions that a [workaround](https://stackoverflow.com/a/24727206) might be needed for iOS. I did try on Safari and it worked without it (on desktop and responsive mode), but don't have a device to test it on. I'm not sure if it's still needed given that the answers are a bit old.