### PR TITLE
Use alternative slug in locale switcher

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,6 +6,7 @@ import { fetchTranslations } from './src/scripts/fetch-translations';
 import { fetchBlogFeed } from './src/scripts/fetch-blog-feed';
 import { fetchRedirects } from './src/scripts/fetch-redirects';
 import { fetchRoutes } from './src/scripts/fetch-routes';
+import { fetchI18nSlugs } from './src/scripts/fetch-i18n-slugs';
 
 export default defineNuxtConfig({
   srcDir: 'src',
@@ -57,6 +58,11 @@ export default defineNuxtConfig({
         }),
       fetchRedirects()
         .then((redirects) => writeFile('./src/public/_redirects', redirects)),
+      fetchI18nSlugs()
+        .then(async (data) => {
+          await mkdir('.cache', { recursive: true });
+          await writeFile('.cache/i18n-slugs.json', JSON.stringify(data));
+        }),
     ])
       // hook expects a promise with no return data
       .then(() => {}),

--- a/src/components/app-header/app-header.vue
+++ b/src/components/app-header/app-header.vue
@@ -38,34 +38,7 @@
             />
           </li>
         </ul>
-        <div class="app-header__link-list app-header__link-list--languages">
-          <template
-            v-for="({ code, name }) in $i18n.locales"
-            :key="code"
-          >
-            <span
-              v-if="code === $i18n.locale()"
-              aria-hidden="true"
-              class="app-header__link-list-item app-header__link-list-item--highlighted"
-            >
-              {{ code }}
-            </span>
-            <div
-              v-else
-              class="app-header__link-list-item"
-            >
-              <a
-                class="app-header__link"
-                :aria-label="$t('switch_to__language_', { language: name }, code)"
-                :lang="code"
-                :href="`/${code}/`"
-                @click="saveLocale(code)"
-              >
-                {{ code }}
-              </a>
-            </div>
-          </template>
-        </div>
+        <language-switcher />
       </div>
     </div>
   </div>
@@ -91,15 +64,6 @@
     },
     methods: {
       createHref,
-      saveLocale (code) {
-        const cookie = document.cookie
-        const langKey = 'nf_lang' // @See https://www.netlify.com/docs/redirects/#geoip-and-language-based-redirects
-        if (cookie.match(new RegExp(langKey) !== null)) {
-          document.cookie = cookie.replace(new RegExp(`${langKey}=[A-Za-z-]+;`), `${langKey}=${code};`)
-        } else {
-          document.cookie = `${langKey}=${code}; path=/; ${cookie}`
-        }
-      }
     },
   }
 </script>
@@ -150,12 +114,6 @@
     display: none;
   }
 
-  .app-header__link-list--languages {
-    display: flex;
-    align-items: center;
-    text-transform: uppercase;
-  }
-
   .app-header__link-list-item {
     padding: 0 calc(var(--spacing-small) / 2);
     font-family: var(--font-sans);
@@ -174,21 +132,6 @@
   .app-header__link:focus {
     padding-bottom: .23rem;
     background: transparent linear-gradient(to top, var(--html-blue) 2px, transparent 2px);
-  }
-
-  .app-header__link-list--languages .app-header__link-list-item {
-    padding-right: var(--spacing-tiny);
-  }
-
-  .app-header__link-list--languages .app-header__link-list-item + .app-header__link-list-item {
-    padding-left: 0;
-    padding-right: 0;
-  }
-
-  .app-header__link-list--languages .app-header__link-list-item + .app-header__link-list-item::before {
-    content: '|';
-    padding-right: var(--spacing-tiny);
-    color: var(--html-blue);
   }
 
   @media screen and (min-width: 800px) {
@@ -213,10 +156,6 @@
 
     .app-header__link-list-item {
       padding: 0 calc(var(--spacing-large) / 2);
-    }
-
-    .app-header__link-list--languages .app-header__link-list-item {
-      padding-right: var(--spacing-tiny);
     }
   }
 

--- a/src/components/app-link/app-link.vue
+++ b/src/components/app-link/app-link.vue
@@ -9,9 +9,9 @@
   });
   const router = useRouter();
 
-  const normalizedTo = withTrailingSlash(
+  const normalizedTo = computed(() =>  withTrailingSlash(
     typeof props.to === 'object' ? router.resolve(props.to).path : props.to
-  );
+  ));
 </script>
 
 <template>

--- a/src/components/language-switcher/language-switcher.vue
+++ b/src/components/language-switcher/language-switcher.vue
@@ -1,0 +1,87 @@
+<template>
+  <div class="language-switcher">
+    <template
+      :key="code"
+      v-for="{ code, name } in $i18n.locales"
+    >
+      <span
+        class="language-switcher__language language-switcher__language--highlighted"
+        v-if="code === $i18n.locale()"
+        aria-hidden="true"
+      >
+        {{ code }}
+      </span>
+      <div
+        v-else
+        class="language-switcher__language"
+      >
+        <app-link
+          external
+          :aria-label="$t('switch_to__language_', { language: name }, code)"
+          :lang="code"
+          :to="getLocaleRoute(code)"
+          @click="saveLocale(code)"
+        >
+          {{ code }}
+        </app-link>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+const i18nSlugs = await useI18nSlugs();
+const route = useRoute();
+
+const getLocaleRoute = (code) => {
+  const localeSlug = i18nSlugs.value?.find((i18nSlug) => i18nSlug.locale === code);
+
+  return {
+    name: route.name,
+    params: {
+      language: code,
+      slug: localeSlug?.value || route.params.slug,
+    },
+  }
+}
+
+const saveLocale = (code) => {
+  const cookie = document.cookie;
+  const langKey = "nf_lang"; // @See https://www.netlify.com/docs/redirects/#geoip-and-language-based-redirects
+  if (cookie.match(new RegExp(langKey) !== null)) {
+    document.cookie = cookie.replace(
+      new RegExp(`${langKey}=[A-Za-z-]+;`),
+      `${langKey}=${code};`
+    );
+  } else {
+    document.cookie = `${langKey}=${code}; path=/; ${cookie}`;
+  }
+};
+</script>
+
+<style>
+  .language-switcher {
+    align-items: center;
+    display: flex;
+    text-transform: uppercase;
+    gap: var(--spacing-tiny);
+    margin-left: var(--spacing-tiny);
+  }
+
+  .language-switcher__language {
+    color: var(--html-blue);
+    font-family: var(--font-sans);
+  }
+
+  .language-switcher__language--highlighted {
+    font-weight: 700;
+  }
+
+  .language-switcher__language + .language-switcher__language::before {
+    content: '|';
+    color: var(--html-blue);
+    font-weight: 400;
+    margin-right: var(--spacing-tiny);
+  }
+
+</style>

--- a/src/composables/usei18nSlugs.js
+++ b/src/composables/usei18nSlugs.js
@@ -1,7 +1,10 @@
 export async function useI18nSlugs() {
     const route = useRoute()
+    const key = [route.name, route.params.slug, 'i18n-slugs']
+        .filter(Boolean)
+        .join('-')
 
-    const { data } = await useAsyncData(`${route.name}-${route.params.slug}-i18n-slugs`, async () => {
+    const { data } = await useAsyncData(key, async () => {
         const i18nRouteConfig = (await import('../../.cache/i18n-slugs.json')).default
         const i18nSlugs = i18nRouteConfig.find((i18nRoute) => i18nRoute.route === route.name)
 
@@ -10,6 +13,8 @@ export async function useI18nSlugs() {
         }
 
         return i18nSlugs.slugs.find(localeConfig => localeConfig.find(({ locale, value }) => value === route.params.slug && locale === route.params.language))
+    }, {
+        watch: [route]
     })
 
     return data

--- a/src/composables/usei18nSlugs.js
+++ b/src/composables/usei18nSlugs.js
@@ -12,7 +12,11 @@ export async function useI18nSlugs() {
             return null
         }
 
-        return i18nSlugs.slugs.find(localeConfig => localeConfig.find(({ locale, value }) => value === route.params.slug && locale === route.params.language))
+        return i18nSlugs.slugs.find(
+            localeConfig => localeConfig.find(
+                ({ locale, value }) => value === route.params.slug && locale === route.params.language
+            )
+        )
     }, {
         watch: [route]
     })

--- a/src/composables/usei18nSlugs.js
+++ b/src/composables/usei18nSlugs.js
@@ -1,0 +1,16 @@
+export async function useI18nSlugs() {
+    const route = useRoute()
+
+    const { data } = await useAsyncData(`${route.name}-${route.params.slug}-i18n-slugs`, async () => {
+        const i18nRouteConfig = (await import('../../.cache/i18n-slugs.json')).default
+        const i18nSlugs = i18nRouteConfig.find((i18nRoute) => i18nRoute.route === route.name)
+
+        if (!i18nSlugs) {
+            return null
+        }
+
+        return i18nSlugs.slugs.find(localeConfig => localeConfig.find(({ locale, value }) => value === route.params.slug && locale === route.params.language))
+    })
+
+    return data
+}

--- a/src/scripts/fetch-i18n-slugs.ts
+++ b/src/scripts/fetch-i18n-slugs.ts
@@ -11,7 +11,7 @@ const operationsWithTranslatedSlugs = [
   },
   {
     route: "language-cases-slug",
-    operation: "allServices",
+    operation: "allCaseItems",
   },
 ];
 

--- a/src/scripts/fetch-i18n-slugs.ts
+++ b/src/scripts/fetch-i18n-slugs.ts
@@ -1,0 +1,119 @@
+const operationsWithTranslatedSlugs = [
+  {
+    route: "language-jobs-slug",
+    operation: "allJobs",
+  },
+  {
+    route: "language-services-slug",
+    operation: "allServices",
+  },
+  {
+    route: "language-cases-slug",
+    operation: "allServices",
+  },
+];
+
+// fetches a paginated list of slugs for a given operation
+const fetchPaginatedTranslatedSlugsForOperation = ({
+  operation,
+  skip,
+}: {
+  operation: string;
+  skip: number;
+}) => {
+  return fetchDatoQuery({
+    query: `
+        query ${operation}($skip: IntType) {
+            ${operation}(first: 100, skip: $skip) {
+              id
+              _allSlugLocales {
+                locale
+                value
+              }
+            }
+        }
+    `,
+    variables: {
+      skip,
+    },
+  })
+    .then((data) =>
+      data[operation].map(
+        ({ _allSlugLocales }: { _allSlugLocales: any }) => _allSlugLocales
+      )
+    );
+};
+
+// fetches the total number of items for a given operation
+const fetchMetaForOperation = ({ operation }: { operation: string }) => {
+  return fetchDatoQuery({
+    query: `
+        query Meta {
+            _${operation}Meta {
+                count
+            }
+        }
+    `,
+  });
+};
+
+// fetches all slugs for operation
+const fetchTranslatedSlugsForOperation = async ({
+  operation,
+}: {
+  operation: string;
+}) => {
+  const meta = await fetchMetaForOperation({ operation });
+  const { count } = meta[`_${operation}Meta`];
+  const pages = Math.ceil(count / 100);
+
+  return Promise.all(
+    [...Array(pages)].map((_, index) =>
+      fetchPaginatedTranslatedSlugsForOperation({
+        operation,
+        skip: index * 100,
+      })
+    )
+  );
+};
+
+// fetches data from DatoCMS using the GraphQL API
+const fetchDatoQuery = ({
+  query,
+  variables = {},
+}: {
+  query: string;
+  variables?: Record<string, unknown>;
+}) => {
+  return fetch("https://graphql.datocms.com/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: process.env.DATO_API_TOKEN,
+    } as HeadersInit,
+    body: JSON.stringify({
+      query,
+      variables,
+    }),
+  })
+    .then((res) => res.json())
+    .then(({ data, errors }) => {
+      if (errors) {
+        console.log(errors);
+      }
+
+      return data;
+    });
+};
+
+export const fetchI18nSlugs = async () => {
+  const test = await Promise.all(
+    operationsWithTranslatedSlugs.map(async ({ route, operation }) => ({
+      route,
+      slugs: (await fetchTranslatedSlugsForOperation({ operation: operation })).flat(),
+    }))
+  );
+
+  return test;
+};

--- a/src/scripts/fetch-routes.ts
+++ b/src/scripts/fetch-routes.ts
@@ -1,5 +1,5 @@
 import { locales } from "../lib/i18n";
-import { datocmsFetch } from '../lib/datocms-fetch.ts';
+import { datocmsFetch } from '../lib/datocms-fetch';
 
 type RouteConfig = {
   queryOperation: string;


### PR DESCRIPTION
Ideally I would use the data returned from `asyncData` on a page in the header, but since that's not possible (because app-header is used in the layout), I made something different.

What's happening:
- Fetch all alternative slugs for pages that have them before dev/build
- Store them in a nice place
- Use them in a `useI18nSlugs` composable, that gives back the alternative slugs for the current route when available
- In the language switcher, generate alternative routes for the current page
    - When available, use locale + alternative slug
    - When not available, use locale + current slug

This way a user is able to switch locale on every page on the site.