### PR TITLE
adjust homepage gql query so it only shows published events

### DIFF
--- a/src/pages/[language]/index.query.graphql
+++ b/src/pages/[language]/index.query.graphql
@@ -2,7 +2,7 @@ query HomePage($locale: SiteLocale, $currentDate: DateTime) {
   page: home(locale: $locale) {
     ...homepage
   }
-  upcomingEvents: allEventItems(locale: $locale, first: 1, orderBy: date_ASC, filter: {date: {gte: $currentDate}}) {
+  upcomingEvents: allEventItems(locale: $locale, first: 1, orderBy: date_ASC, filter: {date: {gte: $currentDate}, published: {eq: true}}) {
     date
     social {
       description


### PR DESCRIPTION
Related ticket: https://trello.com/c/LqcoSrny/635-events-on-homepage

Homepage should not show unpublished events, this PR fixes that.