### PR TITLE
Event page improvements

### DIFF
--- a/src/pages/[language]/events/[slug]/index.vue
+++ b/src/pages/[language]/events/[slug]/index.vue
@@ -40,7 +40,7 @@
             {{ $t('price') }}
           </p>
           <p class="body">
-            € {{ data.page.price }}
+            {{ data.page.price }}
           </p>
         </div>
 

--- a/src/pages/[language]/events/[slug]/index.vue
+++ b/src/pages/[language]/events/[slug]/index.vue
@@ -15,7 +15,7 @@
       <aside class="page-event-detail__aside">
         <div>
           <p class="body font-bold">
-            Date
+            {{ $t('date') }}
           </p>
           <time
             :datetime="data.page.date"
@@ -27,7 +27,7 @@
 
         <div>
           <p class="body font-bold">
-            Location
+            {{ $t('location') }}
           </p>
           <rich-text-block
             :key="formattedAddress"
@@ -37,7 +37,7 @@
 
         <div v-if="data.page.price && data.page.price !== '0'">
           <p class="body font-bold">
-            Price
+            {{ $t('price') }}
           </p>
           <p class="body">
             € {{ data.page.price }}

--- a/src/scripts/fetch-i18n-slugs.ts
+++ b/src/scripts/fetch-i18n-slugs.ts
@@ -13,6 +13,10 @@ const operationsWithTranslatedSlugs = [
     route: "language-cases-slug",
     operation: "allCaseItems",
   },
+  {
+    route: "language-events-slug",
+    operation: "allEventItems",
+  }
 ];
 
 // fetches a paginated list of slugs for a given operation


### PR DESCRIPTION
This PR:

- Adds event pages to the configuration of translated pages
- Uses translated values for labels on event page
- Removes euro sign from price, since it looks weird with things other than numbers