### PR TITLE
Structured text for landing pages

### DIFF
--- a/src/components/app-core/typography.css
+++ b/src/components/app-core/typography.css
@@ -1,11 +1,3 @@
-.hero {
-  font-family: var(--font-sans);
-  font-size: 3.75rem; /* 60px */
-  font-weight: 700;
-  line-height: 1.0166666667; /* 61px */
-  color: var(--html-blue);
-}
-
 .sub-title {
   font-family: var(--font-sans);
   font-size: 1.3125rem; /* 21px */
@@ -19,14 +11,6 @@
   font-size: 1.8125rem; /* 29px */
   font-weight: 400;
   line-height: 1.4482758621; /* 42px */
-}
-
-.sub-title-2 {
-  font-family: var(--font-sans);
-  font-size: 1.25rem; /* 20px */
-  font-weight: 400;
-  line-height: 1.4; /* 28px */
-  color: var(--html-blue);
 }
 
 .pullquote {
@@ -131,11 +115,6 @@
 }
 
 @media (min-width: 720px) {
-  .hero {
-    font-size: 4.375rem; /* 70px */
-    line-height: 1.0285714286; /* 72px */
-  }
-
   .sub-title {
     font-size: 1.875rem; /* 30px */
     line-height: 1.2; /* 36px */
@@ -144,11 +123,6 @@
   .testimonial {
     font-size: 2rem; /* 32px */
     line-height: 1.46875; /* 47px */
-  }
-
-  .sub-title-2 {
-    font-size: 1.625rem; /* 26px */
-    line-height: 1.3461538462; /* 35px */
   }
 
   .pullquote {
@@ -223,11 +197,6 @@
 }
 
 @media (min-width: 1100px) {
-  .hero {
-    font-size: 6.5rem; /* 104px */
-    line-height: 1.0288461538; /* 107px */
-  }
-
   .sub-title {
     font-size: 2.3125rem; /* 37px */
     line-height: 1.2162162162; /* 45px */
@@ -236,11 +205,6 @@
   .testimonial {
     font-size: 2.1875rem; /* 35px */
     line-height: 1.4571428571; /* 51px */
-  }
-
-  .sub-title-2 {
-    font-size: 2rem; /* 32px */
-    line-height: 1.34375; /* 43px */
   }
 
   .pullquote {

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -1,0 +1,136 @@
+<template>
+  <div
+    class="structured-text"
+    :class="{
+      'structured-text--center-grid': gridAlignment === 'center',
+      'structured-text--center-text': textAlignment === 'center',
+      'structured-text--blue-text': textColor === 'blue'
+    }"
+  >
+    <template v-for="(child, index) in props.value.document.children">
+      <p
+        v-if="child.type === 'paragraph'"
+        :key="index"
+        :class="bodySize === 'regular' ? 'body' : `body-${bodySize}`"
+      >
+        <template v-for="(paragraphChild, paragraphIndex) in child.children">
+          <template v-if="paragraphChild.type === 'span'">
+            <strong
+              v-if="paragraphChild.marks?.includes('strong')"
+              :key="`${paragraphIndex}-strong`"
+            >
+              {{ paragraphChild.value }}
+            </strong>
+            <span
+              v-else
+              :key="paragraphIndex"
+            >
+              {{ paragraphChild.value }}
+            </span>
+          </template>
+          <template v-else-if="paragraphChild.type === 'link'">
+            <a
+              :key="paragraphIndex"
+              :href="paragraphChild.url"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ paragraphChild.children[0].value }}
+            </a>
+          </template>
+        </template>
+      </p>
+      <h2
+        v-else-if="child.type === 'heading' && child.level === 2"
+        :key="`${index}-h2`"
+        class="h2"
+      >
+        {{ child.children[0].value }}
+      </h2>
+      <h3
+        v-else-if="child.type === 'heading' && child.level === 3"
+        :key="`${index}-h3`"
+        class="h3"
+      >
+        {{ child.children[0].value }}
+      </h3>
+      <h4
+        v-else-if="child.type === 'heading' && child.level === 4"
+        :key="`${index}-h4`"
+        class="h4"
+      >
+        {{ child.children[0].value }}
+      </h4>
+    </template>
+  </div>
+</template>
+
+<script setup>
+  const props = defineProps({
+    value: {
+      type: Object,
+      default: null
+    },
+    gridAlignment: {
+      type: String,
+      default: 'left'
+    },
+    textAlignment: {
+      type: String,
+      default: 'left'
+    },
+    textColor: {
+      type: String,
+      default: 'default'
+    },
+    bodySize: {
+      type: String,
+      default: 'regular'
+    },
+  });
+</script>
+
+<style>
+  .structured-text {
+    grid-column: var(--grid-content);
+    word-wrap: break-word;
+  }
+
+  @media (min-width: 720px) {
+    .structured-text--center-grid {
+      grid-column-start: 6;
+      grid-column-end: 44;
+    }
+  }
+
+  @media (min-width: 1100px) {
+    .structured-text--center-grid {
+      grid-column-start: 10;
+      grid-column-end: 42;
+    }
+  }
+
+  .structured-text--center-text {
+    text-align: center;
+  }
+
+  .structured-text--blue-text {
+    color: var(--html-blue);
+  }
+
+  .structured-text p:not(:last-child) {
+    margin-bottom: var(--spacing-medium);
+  }
+
+  .structured-text a {
+    color: var(--html-blue);
+    padding-bottom: .15rem;
+    background: transparent linear-gradient(to top, transparent 1px, var(--html-blue) 1px, var(--html-blue) 2px, transparent 2px);
+  }
+
+  .structured-text a:hover,
+  .structured-text a:focus {
+    color: var(--active-blue);
+    background: transparent linear-gradient(to top, var(--html-blue) 2px, transparent 2px);
+  }
+</style>

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -58,14 +58,14 @@
       </component>
 
       <structured-text-block
-        v-else-if="child.type === 'block' && getBlock(child.item).__typename === 'StructuredTextBlueTextRecord'"
+        v-else-if="child.type === 'block' && getBlock(child.item)?.__typename === 'StructuredTextBlueTextRecord'"
         :key="`${index}-blue-text`"
         :content="getBlock(child.item).body"
         class="structured-text__blue-text"
       />
 
       <div
-        v-else-if="child.type === 'block' && getBlock(child.item).__typename === 'StructuredTextCtaListRecord'"
+        v-else-if="child.type === 'block' && getBlock(child.item)?.__typename === 'StructuredTextCtaListRecord'"
         class="structured-text__cta-list"
         :key="`${index}-cta-list`"
       >
@@ -81,6 +81,20 @@
           :external="cta.external"
         />
       </div>
+
+      <ul
+        v-else-if="child.type === 'block' && getBlock(child.item)?.__typename === 'StructuredTextHighlightedListRecord'"
+        class="structured-text__highlighted-list"
+        :key="`${index}-highlighted-list`"
+      >
+        <li
+          v-for="(listItem, listItemIndex) in getBlock(child.item).items"
+          :key="listItemIndex"
+          class="structured-text__highlighted-list-item"
+        >
+          <structured-text-block :content="listItem.body" />
+        </li>
+      </ul>
     </template>
   </div>
 </template>
@@ -143,6 +157,7 @@
   .structured-text__blue-text {
     color: var(--html-blue);
     text-align: center;
+    margin-bottom: var(--spacing-medium);
   }
 
   .structured-text__cta-list {
@@ -152,5 +167,14 @@
     flex-wrap: wrap;
     gap: var(--spacing-small);
     align-self: center;
+  }
+
+  .structured-text__highlighted-list-item {
+    padding: var(--spacing-medium);
+    background-color: var(--white);
+  }
+
+  .structured-text__highlighted-list-item + .structured-text__highlighted-list-item {
+    margin-top: var(--spacing-medium);
   }
 </style>

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -64,11 +64,23 @@
         class="structured-text__blue-text"
       />
 
-      <template
+      <div
         v-else-if="child.type === 'block' && getBlock(child.item).__typename === 'StructuredTextCtaListRecord'"
+        class="structured-text__cta-list"
+        :key="`${index}-cta-list`"
       >
-        {{ getBlock(child.item) }}
-      </template>
+        <app-button
+          v-for="(cta, ctaIndex) in getBlock(child.item).ctas.map((cta) => ({
+            label: cta.title,
+            to: cta.url || cta.link,
+            external: cta.__typename === 'ExternalLinkRecord',
+          }))"
+          :key="ctaIndex"
+          :label="cta.label"
+          :to="cta.to"
+          :external="cta.external"
+        />
+      </div>
     </template>
   </div>
 </template>
@@ -94,6 +106,8 @@
   .structured-text {
     grid-column: var(--grid-content);
     word-wrap: break-word;
+    display: flex;
+    flex-direction: column;
   }
 
   @media (min-width: 720px) {
@@ -114,14 +128,14 @@
     margin-bottom: var(--spacing-medium);
   }
 
-  .structured-text a {
+  .structured-text p a {
     color: var(--html-blue);
     padding-bottom: .15rem;
     background: transparent linear-gradient(to top, transparent 1px, var(--html-blue) 1px, var(--html-blue) 2px, transparent 2px);
   }
 
-  .structured-text a:hover,
-  .structured-text a:focus {
+  .structured-text p a:hover,
+  .structured-text p a:focus {
     color: var(--active-blue);
     background: transparent linear-gradient(to top, var(--html-blue) 2px, transparent 2px);
   }
@@ -129,5 +143,14 @@
   .structured-text__blue-text {
     color: var(--html-blue);
     text-align: center;
+  }
+
+  .structured-text__cta-list {
+    margin-top: var(--spacing-medium);
+    display: inline-flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: var(--spacing-small);
+    align-self: center;
   }
 </style>

--- a/src/pages/[language]/[slug]/index.query.graphql
+++ b/src/pages/[language]/[slug]/index.query.graphql
@@ -80,13 +80,39 @@ query LandingPage($locale: SiteLocale, $slug: String) {
       ...on SectionStructuredTextRecord {
         body {
           value
+          blocks {
+            __typename
+            ... on StructuredTextBlueTextRecord {
+              id
+              body {
+                value
+              }
+            }
+            ... on StructuredTextCtaListRecord {
+              ctas {
+                ...link
+              }
+            }
+          }
         }
         gridAlignment
-        textAlignment
-        textColor
-        bodySize
       }
     }
   }
 }
 
+fragment link on RecordInterface {
+  __typename
+  ... on InternalLinkRecord {
+    title
+    link {
+      ... on LandingPageRecord {
+        slug
+      }
+    }
+  }
+  ... on ExternalLinkRecord {
+    title
+    url
+  }
+}

--- a/src/pages/[language]/[slug]/index.query.graphql
+++ b/src/pages/[language]/[slug]/index.query.graphql
@@ -64,6 +64,7 @@ query LandingPage($locale: SiteLocale, $slug: String) {
         }
       }
       ...on SectionStructuredTextRecord {
+        gridAlignment
         body {
           value
           blocks {
@@ -90,7 +91,6 @@ query LandingPage($locale: SiteLocale, $slug: String) {
             }
           }
         }
-        gridAlignment
       }
     }
   }

--- a/src/pages/[language]/[slug]/index.query.graphql
+++ b/src/pages/[language]/[slug]/index.query.graphql
@@ -28,6 +28,7 @@ query LandingPage($locale: SiteLocale, $slug: String) {
           width
           height
         }
+        imagePosition
       }
       ... on SectionInterstitialCtaRecord {
         title

--- a/src/pages/[language]/[slug]/index.query.graphql
+++ b/src/pages/[language]/[slug]/index.query.graphql
@@ -63,7 +63,6 @@ query LandingPage($locale: SiteLocale, $slug: String) {
           ...link
         }
       }
-
       ...on SectionStructuredTextRecord {
         body {
           value
@@ -79,6 +78,14 @@ query LandingPage($locale: SiteLocale, $slug: String) {
               id
               ctas {
                 ...link
+              }
+            }
+            ... on StructuredTextHighlightedListRecord {
+              id
+              items {
+                body {
+                  value
+                }
               }
             }
           }

--- a/src/pages/[language]/[slug]/index.query.graphql
+++ b/src/pages/[language]/[slug]/index.query.graphql
@@ -76,6 +76,7 @@ query LandingPage($locale: SiteLocale, $slug: String) {
               }
             }
             ... on StructuredTextCtaListRecord {
+              id
               ctas {
                 ...link
               }

--- a/src/pages/[language]/[slug]/index.query.graphql
+++ b/src/pages/[language]/[slug]/index.query.graphql
@@ -76,6 +76,16 @@ query LandingPage($locale: SiteLocale, $slug: String) {
           height
         }
       }
+
+      ...on SectionStructuredTextRecord {
+        body {
+          value
+        }
+        gridAlignment
+        textAlignment
+        textColor
+        bodySize
+      }
     }
   }
 }

--- a/src/pages/[language]/[slug]/index.vue
+++ b/src/pages/[language]/[slug]/index.vue
@@ -54,7 +54,6 @@
       />
       <structured-text-block
         v-if="section.__typename === 'SectionStructuredTextRecord'"
-        :key="index"
         :content="section.body"
         :grid-alignment="section.gridAlignment"
       />

--- a/src/pages/[language]/[slug]/index.vue
+++ b/src/pages/[language]/[slug]/index.vue
@@ -46,11 +46,8 @@
       <structured-text-block
         v-if="section.__typename === 'SectionStructuredTextRecord'"
         :key="index"
-        :value="section.body.value"
+        :content="section.body"
         :grid-alignment="section.gridAlignment"
-        :text-alignment="section.textAlignment"
-        :text-color="section.textColor"
-        :body-size="section.bodySize"
       />
     </template>
   </div>

--- a/src/pages/[language]/[slug]/index.vue
+++ b/src/pages/[language]/[slug]/index.vue
@@ -43,6 +43,15 @@
         :title="section.title"
         :logos="section.logos"
       />
+      <structured-text-block
+        v-if="section.__typename === 'SectionStructuredTextRecord'"
+        :key="index"
+        :value="section.body.value"
+        :grid-alignment="section.gridAlignment"
+        :text-alignment="section.textAlignment"
+        :text-color="section.textColor"
+        :body-size="section.bodySize"
+      />
     </template>
   </div>
 </template>

--- a/src/pages/[language]/[slug]/index.vue
+++ b/src/pages/[language]/[slug]/index.vue
@@ -15,6 +15,7 @@
         :title="section.title"
         :body="section.body"
         :image="section.image"
+        :inverse="section.imagePosition === 'right'"
       />
       <interstitial-cta
         v-if="section.__typename === 'SectionInterstitialCtaRecord'"


### PR DESCRIPTION
Mainly worked on the Structured Text for these pages:
- [Work At](https://deploy-preview-626--voorhoede-website.netlify.app/en/work-at-new?preview=true&previewSecret=blue-unsalted-ravioli)
- [About Us](https://deploy-preview-626--voorhoede-website.netlify.app/en/about-us-new?preview=true&previewSecret=blue-unsalted-ravioli)

Created the following Structured Text blocks:
- Blue text: structured text where all the text is blue and centered (headings are always blue, even outside this block)
- CTA list: list of links that are displayed as buttons
- Highlighted list: list of structured text blocks with a white background

What do you think of the names of the blocks in Dato? 