### PR TITLE
Refactor/structured text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
         "@json-feed-types/1_1": "^1.0.2",
         "@nuxtjs/plausible": "^0.2.0",
         "datocms-listen": "^0.1.14",
+        "datocms-structured-text-utils": "^2.0.4",
         "dayjs": "^1.11.7",
         "nuxt": "^3.3.3",
         "nuxt-icons": "^3.2.1",
         "prismjs": "^1.29.0",
         "rosetta": "^1.1.0",
-        "ufo": "^1.0.1"
+        "ufo": "^1.0.1",
+        "vue-datocms": "^4.0.5"
       },
       "devDependencies": {
         "@typescript-eslint/parser": "^5.57.0",
@@ -2309,6 +2311,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "devOptional": true
     },
+    "node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -3127,6 +3134,22 @@
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/datocms-listen/-/datocms-listen-0.1.14.tgz",
       "integrity": "sha512-Ijd5fzQ1Y1EUiSwduvaPRN7a6Edh//c500/2MjDhgaKd+N+zGEy7rpJ/SVXX0TdYDhX0ssoC4FDms6sbR7k+eA=="
+    },
+    "node_modules/datocms-structured-text-generic-html-renderer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/datocms-structured-text-generic-html-renderer/-/datocms-structured-text-generic-html-renderer-2.0.4.tgz",
+      "integrity": "sha512-Rv5Y1eC9NZXNSz3FHvHGFvGnKEEbvG1kQWlylpCSoeDBZPBwSWAFD/ixIAOfa8Yk1EVpmoQd3KQd725WKYJwRQ==",
+      "dependencies": {
+        "datocms-structured-text-utils": "^2.0.4"
+      }
+    },
+    "node_modules/datocms-structured-text-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/datocms-structured-text-utils/-/datocms-structured-text-utils-2.0.4.tgz",
+      "integrity": "sha512-JxDdJaipm3FePOli9s82MRrBDnlPP9GYhqajQJaYEu4V1jwUSZzbVkYVKMfVHUfP0Gh0VSCxPHjAGGAN1nWMJg==",
+      "dependencies": {
+        "array-flatten": "^3.0.0"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.7",
@@ -4475,6 +4498,11 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -7981,6 +8009,52 @@
         "ufo": "^1.1.1"
       }
     },
+    "node_modules/vue-datocms": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vue-datocms/-/vue-datocms-4.0.5.tgz",
+      "integrity": "sha512-MK1PLTMinFJQF7pOGEs5hfyxMGte48zj73MKk6KZjcjWcZUo1XDMX2wz8YHlW7d4+LC95sJ8twC19WFPruYkcA==",
+      "dependencies": {
+        "datocms-listen": "^0.1.10",
+        "datocms-structured-text-generic-html-renderer": "^2.0.4",
+        "datocms-structured-text-utils": "^2.0.4",
+        "hyphenate-style-name": "^1.0.4",
+        "vue-demi": "^0.13.11"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.7.1",
+        "vue": ">= 2.5 < 2.7 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-datocms/node_modules/vue-demi": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
+      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vue-devtools-stub": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/vue-devtools-stub/-/vue-devtools-stub-0.1.0.tgz",
@@ -9869,6 +9943,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "devOptional": true
     },
+    "array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -10422,6 +10501,22 @@
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/datocms-listen/-/datocms-listen-0.1.14.tgz",
       "integrity": "sha512-Ijd5fzQ1Y1EUiSwduvaPRN7a6Edh//c500/2MjDhgaKd+N+zGEy7rpJ/SVXX0TdYDhX0ssoC4FDms6sbR7k+eA=="
+    },
+    "datocms-structured-text-generic-html-renderer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/datocms-structured-text-generic-html-renderer/-/datocms-structured-text-generic-html-renderer-2.0.4.tgz",
+      "integrity": "sha512-Rv5Y1eC9NZXNSz3FHvHGFvGnKEEbvG1kQWlylpCSoeDBZPBwSWAFD/ixIAOfa8Yk1EVpmoQd3KQd725WKYJwRQ==",
+      "requires": {
+        "datocms-structured-text-utils": "^2.0.4"
+      }
+    },
+    "datocms-structured-text-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/datocms-structured-text-utils/-/datocms-structured-text-utils-2.0.4.tgz",
+      "integrity": "sha512-JxDdJaipm3FePOli9s82MRrBDnlPP9GYhqajQJaYEu4V1jwUSZzbVkYVKMfVHUfP0Gh0VSCxPHjAGGAN1nWMJg==",
+      "requires": {
+        "array-flatten": "^3.0.0"
+      }
     },
     "dayjs": {
       "version": "1.11.7",
@@ -11396,6 +11491,11 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
       "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
+    },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -13858,6 +13958,26 @@
       "integrity": "sha512-EfjX+5TTUl70bki9hPuVp+54JiZOvFIfoWBcfXsSwLzKEiDYyHNi5iX8srnqLIv3YRnvxgbntdcG1WPq0MvffQ==",
       "requires": {
         "ufo": "^1.1.1"
+      }
+    },
+    "vue-datocms": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vue-datocms/-/vue-datocms-4.0.5.tgz",
+      "integrity": "sha512-MK1PLTMinFJQF7pOGEs5hfyxMGte48zj73MKk6KZjcjWcZUo1XDMX2wz8YHlW7d4+LC95sJ8twC19WFPruYkcA==",
+      "requires": {
+        "datocms-listen": "^0.1.10",
+        "datocms-structured-text-generic-html-renderer": "^2.0.4",
+        "datocms-structured-text-utils": "^2.0.4",
+        "hyphenate-style-name": "^1.0.4",
+        "vue-demi": "^0.13.11"
+      },
+      "dependencies": {
+        "vue-demi": {
+          "version": "0.13.11",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
+          "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+          "requires": {}
+        }
       }
     },
     "vue-devtools-stub": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
     "@json-feed-types/1_1": "^1.0.2",
     "@nuxtjs/plausible": "^0.2.0",
     "datocms-listen": "^0.1.14",
+    "datocms-structured-text-utils": "^2.0.4",
     "dayjs": "^1.11.7",
     "nuxt": "^3.3.3",
     "nuxt-icons": "^3.2.1",
     "prismjs": "^1.29.0",
     "rosetta": "^1.1.0",
-    "ufo": "^1.0.1"
+    "ufo": "^1.0.1",
+    "vue-datocms": "^4.0.5"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^5.57.0",

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -1,16 +1,13 @@
 <template>
-  <div
+  <DatocmsStructuredText
+    :data="content"
+    :render-block="renderBlock"
+    :custom-node-rules="customNodeRules"
     class="structured-text"
     :class="{
       'structured-text--center-grid': gridAlignment === 'center',
     }"
-  >
-    <DatocmsStructuredText
-      :data="content"
-      :render-block="renderBlock"
-      :custom-node-rules="customNodeRules"
-    />
-  </div>
+  />
 </template>
 
 <script setup>


### PR DESCRIPTION
## What changed

Refactor structured text block to use `vue-datocms` package.

## Rationale

- I think most developers are used to using the vue-datocms package (or another framework's equivalent). Since De Voorhoede's site is worked on by so many people, I prefer sticking to how it's done in many of our projects.
- Performance isn't too bad. The added package is 22k parse size, but the total added resource size is just 8kb. Probably since we got rid of a lot of custom templating. Also I think the `renderBlock` syntax scales a bit more efficiently when adding more blocks to it later.
