### PR TITLE
Fix/cut off images

### DIFF
--- a/src/components/responsive-image/responsive-image.vue
+++ b/src/components/responsive-image/responsive-image.vue
@@ -39,7 +39,6 @@
     margin-right: auto;
     width: 100%;
     height: 100%;
-    object-fit: cover;
   }
 
   .responsive-image__caption {

--- a/src/pages/[language]/services/[slug]/index.vue
+++ b/src/pages/[language]/services/[slug]/index.vue
@@ -34,7 +34,6 @@
           :id="item.id"
           :image="item.image"
           :caption="item.caption"
-          :has-fixed-ratio="true"
         />
         <responsive-video
           :id="item.id"


### PR DESCRIPTION
## What changed

- Don't use `object-fit: cover` on responsive image. We already use `width` and `height` attributes, so it's not necessary
- Before, images were trying to cover the caption of the responsive image component as well: https://www.voorhoede.nl/nl/services/design-system/

## How to test

- Go to /nl/services/design-system/ on deploy preview and verify the image is not cut off anymore.