### PR TITLE
Allow linking to Landing Page

### DIFF
--- a/migrations/1683803030_allowLandingPageOnLink.ts
+++ b/migrations/1683803030_allowLandingPageOnLink.ts
@@ -1,0 +1,31 @@
+import { Client } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Single link field "Page" (`page`) in model "Link" (`link`)'
+  );
+  await client.fields.update("214320", {
+    validators: {
+      item_item_type: {
+        on_publish_with_unpublished_references_strategy: "fail",
+        on_reference_unpublish_strategy: "delete_references",
+        on_reference_delete_strategy: "delete_references",
+        item_types: [
+          "38234",
+          "38235",
+          "38237",
+          "38238",
+          "38242",
+          "38245",
+          "40014",
+          "40180",
+          "40181",
+          "862258",
+          "2035421",
+        ],
+      },
+    },
+  });
+}

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'section-timeline-deploy';
+export const datocmsEnvironment = 'landing-page-links';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'landing-page-links';
+export const datocmsEnvironment = 'landing-page-links-deploy';

--- a/src/layouts/default.query.graphql
+++ b/src/layouts/default.query.graphql
@@ -60,6 +60,9 @@ query DefaultLayout($locale: SiteLocale) {
         ... on WorkatRecord {
           slug
         }
+        ... on LandingPageRecord {
+          slug
+        }
       }
     }
   }

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -150,6 +150,9 @@ fragment page on BlogPostRecord {
         ... on ContactRecord {
           slug
         }
+        ... on LandingPageRecord {
+          slug
+        }
       }
     }
     externalLink

--- a/src/pages/[language]/blog/page/index.query.graphql
+++ b/src/pages/[language]/blog/page/index.query.graphql
@@ -90,6 +90,9 @@ fragment blogPostOverview on BlogPostOverviewRecord {
         ... on ContactRecord {
           slug
         }
+        ... on LandingPageRecord {
+          slug
+        }
       }
     }
     externalLink

--- a/src/pages/[language]/cases/[slug]/index.query.graphql
+++ b/src/pages/[language]/cases/[slug]/index.query.graphql
@@ -180,6 +180,9 @@ fragment caseItem on CaseItemRecord {
         ... on ContactRecord {
           slug
         }
+        ... on LandingPageRecord {
+          slug
+        }
       }
     }
     externalLink

--- a/src/pages/[language]/cases/index.query.graphql
+++ b/src/pages/[language]/cases/index.query.graphql
@@ -98,6 +98,9 @@ fragment page on CaseOverviewRecord {
         ... on ContactRecord {
           slug
         }
+        ... on LandingPageRecord {
+          slug
+        }
       }
     }
     externalLink

--- a/src/pages/[language]/contact/[slug]/index.query.graphql
+++ b/src/pages/[language]/contact/[slug]/index.query.graphql
@@ -55,6 +55,9 @@ fragment page on ContactConfirmationRecord {
         ... on ContactRecord {
           slug
         }
+        ... on LandingPageRecord {
+          slug
+        }
       }
     }
     externalLink

--- a/src/pages/[language]/index.query.graphql
+++ b/src/pages/[language]/index.query.graphql
@@ -145,6 +145,9 @@ fragment homepage on HomeRecord {
         ... on ContactRecord {
           slug
         }
+        ... on LandingPageRecord {
+          slug
+        }
       }
     }
     externalLink

--- a/src/pages/[language]/services/[slug]/index.query.graphql
+++ b/src/pages/[language]/services/[slug]/index.query.graphql
@@ -151,6 +151,9 @@ fragment page on ServiceRecord {
         ... on ContactRecord {
           slug
         }
+        ... on LandingPageRecord {
+          slug
+        }
       }
     }
     externalLink

--- a/src/pages/[language]/services/index.query.graphql
+++ b/src/pages/[language]/services/index.query.graphql
@@ -95,6 +95,9 @@ fragment servicespage on ServiceOverviewRecord {
         ... on ContactRecord {
           slug
         }
+        ... on LandingPageRecord {
+          slug
+        }
       }
     }
     externalLink


### PR DESCRIPTION
Ticket: https://trello.com/c/MzA9Fzcr

**Changes:**
- Migration to allow `Landing Page` as one of the models that can be used on the `page` field on the `Link` model
- Changes to all `link { page { ...` queries to query the `LandingPageRecord`

**Test:** the `About Us` link on the navbar takes you to the new page (don't apply this content change in the deploy env during the merge process)
https://deploy-preview-643--voorhoede-website.netlify.app/