### PR TITLE
fix(useSeoHead): decode encoded route params

### DIFF
--- a/src/composables/useSeoHead.js
+++ b/src/composables/useSeoHead.js
@@ -37,15 +37,19 @@ export function useSeoHead({ title, slug, i18nSlugs, social }) {
           rel: 'alternate',
           hreflang: code,
           href: withTrailingSlash(
-            new URL(
-              router.resolve({
-                params: {
-                  language: code,
-                  slug: i18nSlugs?.find((i18nSlug) => i18nSlug.locale === code).value || slug,
-                },
-              }).path,
-              runtimeConfig.public.baseUrl,
-            ).href
+            // Decode the route to make sure slashes in slug are not encoded
+            // Vue router doesn't have an option to disable encoding on router.resolve
+            decodeURIComponent(
+              new URL(
+                router.resolve({
+                  params: {
+                    language: code,
+                    slug: i18nSlugs?.find((i18nSlug) => i18nSlug.locale === code).value || slug,
+                  },
+                }).path,
+                runtimeConfig.public.baseUrl,
+              ).href
+            )
           )
         })),
     ],


### PR DESCRIPTION
## What changes were made

Decode encoded slugs by nuxt router

## How to test or check results

Check alternate hreflang attributes on /en/accessibility/amsterdam?preview=true&previewSecret=blue-unsalted-ravioli. They now shouldn't contain url encoded slashes anymore.

## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [ ] Appointed PR reviewers
