### PR TITLE
Fix/680 blog like landing page tweaks

### DIFF
--- a/migrations/1684748288_blogLikeLandingPageTweaks.ts
+++ b/migrations/1684748288_blogLikeLandingPageTweaks.ts
@@ -81,4 +81,20 @@ export default async function (client: Client) {
       },
     },
   });
+
+  console.log(
+    'Update Structured text field "Blue body" (`body`) in block model "Structured Text - Blue Text" (`structured_text_blue_text`)'
+  );
+  await client.fields.update("10483442", {
+    validators: {
+      required: {},
+      structured_text_blocks: { item_types: ["2040408"] },
+      structured_text_links: {
+        on_publish_with_unpublished_references_strategy: "fail",
+        on_reference_unpublish_strategy: "delete_references",
+        on_reference_delete_strategy: "delete_references",
+        item_types: [],
+      },
+    },
+  });
 }

--- a/migrations/1684748288_blogLikeLandingPageTweaks.ts
+++ b/migrations/1684748288_blogLikeLandingPageTweaks.ts
@@ -1,0 +1,84 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  const newFields: Record<string, SimpleSchemaTypes.Field> = {};
+  const newFieldsets: Record<string, SimpleSchemaTypes.Fieldset> = {};
+
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create fieldset "Configuration" in model "Landing Page" (`landing_page`)'
+  );
+  newFieldsets["573474"] = await client.fieldsets.create("2035421", {
+    title: "Configuration",
+    collapsible: true,
+  });
+
+  console.log(
+    'Create Single-line string field "Background color" (`background_color`) in model "Landing Page" (`landing_page`)'
+  );
+  newFields["9341651"] = await client.fields.create("2035421", {
+    label: "Background color",
+    field_type: "string",
+    api_key: "background_color",
+    validators: { required: {}, enum: { values: ["white", "pastel-yellow"] } },
+    appearance: {
+      addons: [],
+      editor: "single_line",
+      parameters: { heading: false },
+    },
+    default_value: "white",
+    fieldset: newFieldsets["573474"],
+  });
+
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update fieldset "Configuration" in model "Landing Page" (`landing_page`)'
+  );
+  await client.fieldsets.update(newFieldsets["573474"], { position: 2 });
+
+  console.log(
+    'Update Single-line string field "Background color" (`background_color`) in model "Landing Page" (`landing_page`)'
+  );
+  await client.fields.update(newFields["9341651"], { position: 0 });
+
+  console.log(
+    'Update fieldset "Content" in model "Landing Page" (`landing_page`)'
+  );
+  await client.fieldsets.update("574681", { collapsible: true });
+
+  console.log(
+    'Update Modular content field "Sections" (`sections`) in model "Landing Page" (`landing_page`)'
+  );
+  await client.fields.update("10461611", {
+    appearance: {
+      addons: [],
+      editor: "rich_text",
+      parameters: { start_collapsed: true },
+    },
+  });
+
+  console.log(
+    'Update fieldset "Metadata" in model "Landing Page" (`landing_page`)'
+  );
+  await client.fieldsets.update("574680", { collapsible: true });
+
+  console.log(
+    'Update Structured text field "Body" (`body`) in block model "Section Structured Text" (`section_structured_text`)'
+  );
+  await client.fields.update("10483125", {
+    validators: {
+      required: {},
+      structured_text_blocks: {
+        item_types: ["41672", "1775016", "2040400", "2040401", "2040408"],
+      },
+      structured_text_links: {
+        on_publish_with_unpublished_references_strategy: "fail",
+        on_reference_unpublish_strategy: "delete_references",
+        on_reference_delete_strategy: "delete_references",
+        item_types: [],
+      },
+    },
+  });
+}

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -40,6 +40,7 @@ export default {
   import { isHeading, isParagraph, isList  } from 'datocms-structured-text-utils'
   import AppButton from '../app-button/app-button.vue'
   import TagList from '../tag-list/tag-list.vue'
+  import ImageWithCaption from '../image-with-caption/image-with-caption.vue'
   import StructuredTextBlock from './structured-text-block.vue'
 
   const props = defineProps({
@@ -141,6 +142,13 @@ export default {
           items: record.items
         })
       }
+      case 'ImageRecord': {
+        return h(ImageWithCaption, {
+          class: 'structured-text__image-with-caption',
+          caption: record.caption,
+          image: record.image,
+        })
+      }
       default: {
         return null
       }
@@ -236,6 +244,10 @@ export default {
     flex-wrap: wrap;
     gap: var(--spacing-small);
     align-self: center;
+  }
+
+  .structured-text__image-with-caption {
+    margin: var(--spacing-big) 0;
   }
 
   .structured-text__highlighted-list-item {

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -243,6 +243,9 @@ export default {
     align-items: flex-start;
     flex-wrap: wrap;
     gap: var(--spacing-small);
+  }
+
+  .structured-text__blue-text .structured-text__buttons-list {
     align-self: center;
   }
 

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'landing-previews-deploy';
+export const datocmsEnvironment = 'blog-like-landing-page-tweaks';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'blog-like-landing-page-tweaks';
+export const datocmsEnvironment = 'blog-like-landing-page-tweaks-deploy';

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -6,6 +6,7 @@ query LandingPage($locale: SiteLocale, $slug: String) {
       title
       description
     }
+    backgroundColor
     sections {
       __typename
       ... on SectionHeaderRecord {

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -99,6 +99,13 @@ query LandingPage($locale: SiteLocale, $slug: String) {
                 label
               }
             }
+            ... on ImageRecord {
+              id
+              caption
+              image {
+                ...image
+              }
+            }
           }
         }
       }

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -75,13 +75,16 @@ query LandingPage($locale: SiteLocale, $slug: String) {
               id
               body {
                 value
+                blocks {
+                  __typename
+                  ... on StructuredTextButtonsListRecord {
+                    ...buttonsList
+                  }
+                }
               }
             }
             ... on StructuredTextButtonsListRecord {
-              id
-              buttons {
-                ...link
-              }
+              ...buttonsList
             }
             ... on StructuredTextHighlightedListRecord {
               id
@@ -164,6 +167,13 @@ query LandingPage($locale: SiteLocale, $slug: String) {
         }
       }
     }
+  }
+}
+
+fragment buttonsList on StructuredTextButtonsListRecord {
+  id
+  buttons {
+    ...link
   }
 }
 

--- a/src/pages/[language]/[...slug]/index.vue
+++ b/src/pages/[language]/[...slug]/index.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="landing-page grid">
+  <div
+    class="landing-page grid"
+    :class="{
+      'landing-page--pastel-background': data.page.backgroundColor === 'pastel-yellow',
+    }"
+  >
     <template
       v-for="(section, index) in data.page.sections"
       :key="index"
@@ -107,7 +112,7 @@
 </script>
 
 <style>
-  .landing-page {
+  .landing-page--pastel-background {
     background: var(--bg-pastel);
   }
 


### PR DESCRIPTION
## What changes were made

- Customisable background on landing pages
- Allow image in structured text
- Allow button list in structured text blue text, so we can only center buttons in these records. Otherwise they're left aligned

## How to test or check results

- Check /en/digital-products-accessible-for-everyone?preview=true&previewSecret=blue-unsalted-ravioli
- For the button list, check /en/work-at-new?preview=true&previewSecret=blue-unsalted-ravioli at the `De Voorhoede is looking for extra power` section

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
