### PR TITLE
Feat/680 landing page highlighted text options

### DIFF
--- a/migrations/1684831105_structuredTextBlueConfigurableVariant.ts
+++ b/migrations/1684831105_structuredTextBlueConfigurableVariant.ts
@@ -1,0 +1,23 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  const newFields: Record<string, SimpleSchemaTypes.Field> = {};
+
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create Single-line string field "Variant" (`variant`) in block model "Structured Text - Blue Text" (`structured_text_blue_text`)'
+  );
+  newFields["9359142"] = await client.fields.create("2040400", {
+    label: "Variant",
+    field_type: "string",
+    api_key: "variant",
+    validators: { required: {}, enum: { values: ["default", "intro"] } },
+    appearance: {
+      addons: [],
+      editor: "single_line",
+      parameters: { heading: false },
+    },
+    default_value: "default",
+  });
+}

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -55,7 +55,7 @@ export default {
     paragraphVariant: {
       type: String,
       default: 'body',
-      validator: (variant) => ['body', 'body-big'].includes(variant),
+      validator: (variant) => ['body', 'body-big', 'testimonial'].includes(variant),
     },
     hasToc: {
       type: Boolean,
@@ -117,7 +117,7 @@ export default {
         return h(StructuredTextBlock, {
           key,
           content: record.body,
-          paragraphVariant: props.paragraphVariant,
+          paragraphVariant: record.variant === 'intro' ? 'testimonial' : props.paragraphVariant,
           isRoot: false,
           class: 'structured-text__blue-text',
           onUpdateTocItems: updateTocItems,

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'landing-page-blue-text-variants ';
+export const datocmsEnvironment = 'landing-page-blue-text-variants-deploy';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'blog-like-landing-page-tweaks-deploy';
+export const datocmsEnvironment = 'landing-page-blue-text-variants ';

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -82,6 +82,7 @@ query LandingPage($locale: SiteLocale, $slug: String) {
                   }
                 }
               }
+              variant
             }
             ... on StructuredTextButtonsListRecord {
               ...buttonsList

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -73,6 +73,7 @@ query LandingPage($locale: SiteLocale, $slug: String) {
             __typename
             ... on StructuredTextBlueTextRecord {
               id
+              variant
               body {
                 value
                 blocks {
@@ -82,7 +83,6 @@ query LandingPage($locale: SiteLocale, $slug: String) {
                   }
                 }
               }
-              variant
             }
             ... on StructuredTextButtonsListRecord {
               ...buttonsList


### PR DESCRIPTION
## What changes were made

Add a variant field to the blue text record in structured text, so we can render these records like intros on the blog pages

## How to test or check results

Check the intro of /en/impact/digital-products-accessible-for-everyone/, while the _De Voorhoede is looking for extra power_ section on /en/work-at-new/ is untouched.

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
