### PR TITLE
fix(structured-text-block): don't render empty elements

### DIFF
--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -1,19 +1,12 @@
 <template>
-  <div
-    class="structured-text__toc-container"
+  <toc-section
+    v-if="hasToc"
+    :items="tocItems"
+    class="structured-text__toc"
     :class="{
-      'structured-text__toc-container--center-grid': gridAlignment === 'center',
+      'structured-text__toc--center-grid': gridAlignment === 'center',
     }"
-  >
-    <toc-section
-      v-if="hasToc"
-      :items="tocItems"
-      class="structured-text__toc"
-      :class="{
-        'structured-text__toc--center-grid': gridAlignment === 'center',
-      }"
-    />
-  </div>
+  />
   <DatocmsStructuredText
     v-bind="$attrs"
     :data="content"
@@ -167,13 +160,10 @@ export default {
 </script>
 
 <style>
-  .structured-text__toc-container {
-    grid-column-start: 3;
-    grid-column-end: 10;
-  }
-
   .structured-text__toc {
     margin-top: 0;
+    grid-column-start: 3;
+    grid-column-end: 10;
   }
 
   .structured-text {
@@ -198,7 +188,7 @@ export default {
       grid-column-start: 18;
     }
 
-    .structured-text__toc-container--center-grid {
+    .structured-text__toc--center-grid {
       grid-column-start: 8;
       grid-column-end: 15;
     }
@@ -277,6 +267,6 @@ export default {
   }
 
   .structured-text__list li + li {
-    margin-top: var(--spacing-larger);
+    margin-top: var(--spacing-medium);
   }
 </style>


### PR DESCRIPTION
## What changes were made

- Currently there's an empty div causing excessive margin when there's no TOC on structured text blocks, as you can see at https://www.voorhoede.nl/en/impact/digital-products-accessible-for-everyone?preview=true&previewSecret=blue-unsalted-ravioli:
![Screenshot 2023-05-23 at 15 52 38](https://github.com/voorhoede/voorhoede-website/assets/14164215/39d28bfd-9ca7-4648-a0ff-d3a474befd8c)
- Don't render any empty elements in the landing page's grid root
  - I've removed the toc container and put all the conditions and classes directly on the toc itself

## How to test or check results

Check /en/impact/digital-products-accessible-for-everyone. You can locally change your `datocmsEnvironment` to `frank` to see the page with a TOC. (This sandbox can be removed after merging. It's just there to test with a TOC)

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
