### PR TITLE
Feat/structured text blue text alignment options

### DIFF
--- a/migrations/1684934847_structuredTextblueTextRecordAlignmentOptions.ts
+++ b/migrations/1684934847_structuredTextblueTextRecordAlignmentOptions.ts
@@ -1,0 +1,23 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  const newFields: Record<string, SimpleSchemaTypes.Field> = {};
+
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create Single-line string field "Text alignment" (`text_alignment`) in block model "Structured Text - Blue Text" (`structured_text_blue_text`)'
+  );
+  newFields["7968708"] = await client.fields.create("2040400", {
+    label: "Text alignment",
+    field_type: "string",
+    api_key: "text_alignment",
+    validators: { required: {}, enum: { values: ["left", "center"] } },
+    appearance: {
+      addons: [],
+      editor: "single_line",
+      parameters: { heading: false },
+    },
+    default_value: "left",
+  });
+}

--- a/src/components/image-with-text-block/image-with-text-block.vue
+++ b/src/components/image-with-text-block/image-with-text-block.vue
@@ -88,10 +88,6 @@
     background-color: var(--white);
   }
 
-  .image-with-text__body-text .structured-text__blue-text {
-    text-align: left;
-  }
-
   @media (min-width: 720px) {
     .image-with-text {
       display: flex;

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -115,7 +115,10 @@ export default {
           content: record.body,
           paragraphVariant: record.variant === 'intro' ? 'testimonial' : props.paragraphVariant,
           isRoot: false,
-          class: 'structured-text__blue-text',
+          class: {
+            'structured-text__blue-text': true,
+            'structured-text__blue-text--center': record.textAlignment === 'center'
+          },
           onUpdateTocItems: updateTocItems,
         })
       }
@@ -226,8 +229,11 @@ export default {
 
   .structured-text__blue-text {
     color: var(--html-blue);
-    text-align: center;
     margin-bottom: var(--spacing-medium);
+  }
+
+  .structured-text__blue-text--center {
+    text-align: center;
   }
 
   .structured-text__buttons-list {
@@ -238,7 +244,7 @@ export default {
     gap: var(--spacing-small);
   }
 
-  .structured-text__blue-text .structured-text__buttons-list {
+  .structured-text__blue-text--center .structured-text__buttons-list {
     align-self: center;
   }
 

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'blue-text-alignment-options';
+export const datocmsEnvironment = 'structured-text-blue-text-alignment-options-deploy';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'image-with-text-structured-text-remove-legacy-body-fields-deploy';
+export const datocmsEnvironment = 'blue-text-alignment-options';

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -28,6 +28,7 @@ query LandingPage($locale: SiteLocale, $slug: String) {
             __typename
             ... on StructuredTextBlueTextRecord {
               id
+              textAlignment
               body {
                 value
               }
@@ -91,6 +92,7 @@ query LandingPage($locale: SiteLocale, $slug: String) {
             ... on StructuredTextBlueTextRecord {
               id
               variant
+              textAlignment
               body {
                 value
                 blocks {


### PR DESCRIPTION
## What changes were made

Add an option in the cms to determine the text alignment

## How to test or check results

The following pages should be visually unchanged:
- /en/about-us/
- /en/work-at-new

While the following page's introduction should be left aligned:

- /en/impact/digital-products-accessible-for-everyone

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
