### PR TITLE
Fix/margins structured text

### DIFF
--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -207,6 +207,10 @@ export default {
     }
   }
 
+  .structured-text > *:not(:last-child) {
+    margin-bottom: var(--spacing-medium);
+  }
+
   .structured-text__title:not(:last-child) {
     margin-bottom: var(--spacing-medium);
   }

--- a/src/pages/[language]/[...slug]/index.vue
+++ b/src/pages/[language]/[...slug]/index.vue
@@ -141,7 +141,8 @@ function getSectionBackgroundColor(section) {
     padding-top: var(--spacing-big);
   }
 
-  .landing-page__section--background {
+  .landing-page__section--background,
+  .landing-page__section:last-child {
     padding-bottom: var(--spacing-big);
   }
 


### PR DESCRIPTION
## What changes were made

- Provide margin on direct children of structured text block
- Provide some padding-bottom on the section on the page, so it will never stick to the bottom of the page

## How to test or check results

Check /en/impact/digital-products-accessible-for-everyone:
- Currently empty `p` elements are used to create white space before the "How is your business doing right now in accessiblity?" heading. If you remove this `p` from the DOM it should still look good now
- The bottom of this page should also look a bit prettier

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
