### PR TITLE
Add appropriate `sizes` attribute to image with caption

### DIFF
--- a/src/components/gallery-block/gallery-block.vue
+++ b/src/components/gallery-block/gallery-block.vue
@@ -1,10 +1,15 @@
 <template>
   <div class="gallery-block">
-    <image-with-caption
+    <dato-image
       v-for="image in images"
       :key="image.id"
       class="gallery-block__image"
-      :image="image"
+      :src="image.url"
+      :width="image.width"
+      :height="image.height"
+      :alt="image.alt || ''"
+      sizes="(min-width: 1100px) 650px, 45vw"
+      loading="lazy"
     />
   </div>
 </template>
@@ -29,6 +34,8 @@
   .gallery-block__image {
     flex-grow: 1;
     flex-basis: 50%;
+    width: 100%;
+    height: auto;
   }
 
   .gallery-block__image .image-with-caption__image {

--- a/src/components/image-with-caption/image-with-caption.vue
+++ b/src/components/image-with-caption/image-with-caption.vue
@@ -7,7 +7,7 @@
       :width="image.width"
       :height="image.height"
       loading="eager"
-      sizes="100vw"
+      :sizes="image.sizes"
     />
     <div
       v-if="caption"
@@ -26,7 +26,8 @@ defineProps<{
     height: number,
     url: string,
     alt?: string,
-  }
+    sizes: string,
+  },
 }>()
 </script>
 

--- a/src/components/image-with-text-block/image-with-text-block.vue
+++ b/src/components/image-with-text-block/image-with-text-block.vue
@@ -12,7 +12,7 @@
       alt=""
       :width="image.width"
       :height="image.height"
-      sizes="(min-width: 1100px) 730px, (min-width: 720px) 40vw, 100vw"
+      sizes="(min-width: 1100px) 730px, (min-width: 720px) 40vw, 90vw"
       loading="eager"
       :quality="55"
     />

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -140,7 +140,10 @@
         return h(ImageWithCaption, {
           class: 'structured-text__image-with-caption',
           caption: record.caption,
-          image: record.image,
+          image: {
+            ...record.image,
+            sizes: '(min-width: 1100px) 860px, (min-width: 720px) 75vw, 90vw',
+          },
         })
       }
       default: {

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -92,7 +92,12 @@
           :class="{ 'page-blog-post-list--full-width' : item.fullWidth}"
           v-if="item.__typename === 'ImageRecord' && item.image"
           :key="item.id"
-          :image="item.image"
+          :image="{
+            ...item.image,
+            sizes: item.fullWidth
+              ? '(min-width: 1440px) 860px, (min-width: 720px) 75vw, 95vw'
+              : '(min-width: 1440px) 640px, (min-width: 720px) 65vw, 95vw',
+          }"
           :caption="item.caption"
         />
 

--- a/src/pages/[language]/cases/[slug]/index.vue
+++ b/src/pages/[language]/cases/[slug]/index.vue
@@ -68,7 +68,10 @@
           :id="item.id"
           v-if="item.__typename === 'ImageRecord'"
           :key="item.id"
-          :image="item.image"
+          :image="{
+            ...item.image,
+            sizes: '(min-width: 1440px) 1300px, (min-width: 1100px) 1060px, 95vw',
+          }"
           :caption="item.caption"
         />
 

--- a/src/pages/[language]/contact/index.vue
+++ b/src/pages/[language]/contact/index.vue
@@ -15,8 +15,12 @@
           v-for="contact in data.page.contacts"
           :key="contact.title"
         >
-          <image-with-caption
-            :image="contact.image"
+          <dato-image
+            :src="contact.image.url"
+            :width="contact.image.width"
+            :height="contact.image.height"
+            alt=""
+            loading="eager"
             class="page-contact__contact-image"
           />
 

--- a/src/pages/[language]/events/[slug]/index.vue
+++ b/src/pages/[language]/events/[slug]/index.vue
@@ -53,10 +53,15 @@
       </aside>
 
       <article class="page-event-detail__main">
-        <image-with-caption
+        <dato-image
           v-if="!imageIsIllustration && data.page.image"
           class="page-event-detail__image"
-          :image="data.page.image"
+          :src="data.page.image.url"
+          alt=""
+          :width="data.page.image.width"
+          :height="data.page.image.height"
+          sizes="(min-width: 1440px) 640px, (min-width: 720px) 65vw, 95vw"
+          loading="eager"
         />
 
         <template v-for="item in data.page.items">
@@ -82,7 +87,12 @@
             :class="{ 'page-event-detail__main--not-indented' : item.fullWidth}"
             v-if="item.__typename === 'ImageRecord' && item.image"
             :key="item.image.url"
-            :image="item.image"
+            :image="{
+              ...item.image,
+              sizes: item.fullWidth
+                ? '(min-width: 1440px) 860px, (min-width: 720px) 75vw, 95vw'
+                : '(min-width: 1440px) 640px, (min-width: 720px) 65vw, 95vw',
+            }"
             :caption="item.caption"
           />
 
@@ -233,6 +243,8 @@
   .page-event-detail__image {
     justify-content: space-between;
     margin-bottom: var(--spacing-large);
+    width: 100%;
+    height: auto;
   }
 
   .page-event-detail__image .image-with-description__description {

--- a/src/pages/[language]/services/[slug]/index.vue
+++ b/src/pages/[language]/services/[slug]/index.vue
@@ -32,7 +32,10 @@
           v-if="item.__typename === 'ImageRecord'"
           :key="item.id"
           :id="item.id"
-          :image="item.image"
+          :image="{
+            ...item.image,
+            sizes: '(min-width: 1440px) 840px, (min-width: 720px) 65vw, 95vw',
+          }"
           :caption="item.caption"
         />
         <responsive-video


### PR DESCRIPTION
## What changes were made
In prep for https://trello.com/c/znFomEnl/651-combine-image-with-caption-image-with-description-components
This cost me quite some time already and I think I'll focus on something else tomorrow so I put the ticket back to 'todo'.

## How to test or check results
Comparing image data transferred (on desktop):
/en/blog/switching-google-analytics-privacy-friendly-tracking-6-steps/
Before: 870kb, After: 401kb

/en/services/strengthen-your-team/
Before: 1MB, After: 500kb

<!-- URL or instructions -->

## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [ ] Appointed PR reviewers
