### PR TITLE
Refactor/structured text image block configurable width

### DIFF
--- a/migrations/1686733385_addStructuredTextImageBlock.ts
+++ b/migrations/1686733385_addStructuredTextImageBlock.ts
@@ -1,0 +1,99 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  const newFields: Record<string, SimpleSchemaTypes.Field> = {};
+  const newItemTypes: Record<string, SimpleSchemaTypes.ItemType> = {};
+
+  console.log("Create new models/block models");
+
+  console.log(
+    'Create block model "Structured text image" (`structured_text_image`)'
+  );
+  newItemTypes["1897306"] = await client.itemTypes.create(
+    {
+      name: "Structured text image",
+      api_key: "structured_text_image",
+      modular_block: true,
+      inverse_relationships_enabled: false,
+    },
+    { skip_menu_item_creation: true }
+  );
+
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create Single asset field "Image" (`image`) in block model "Structured text image" (`structured_text_image`)'
+  );
+  newFields["9864789"] = await client.fields.create(newItemTypes["1897306"], {
+    label: "Image",
+    field_type: "file",
+    api_key: "image",
+    validators: {
+      required: {},
+      extension: { extensions: [], predefined_list: "image" },
+      required_alt_title: { title: false, alt: true },
+    },
+    appearance: { addons: [], editor: "file", parameters: {} },
+  });
+
+  console.log(
+    'Create Single-line string field "Caption" (`caption`) in block model "Structured text image" (`structured_text_image`)'
+  );
+  newFields["9864790"] = await client.fields.create(newItemTypes["1897306"], {
+    label: "Caption",
+    field_type: "string",
+    api_key: "caption",
+    appearance: {
+      addons: [],
+      editor: "single_line",
+      parameters: { heading: false },
+    },
+    default_value: "",
+  });
+
+  console.log(
+    'Create Single-line string field "Layout" (`layout`) in block model "Structured text image" (`structured_text_image`)'
+  );
+  newFields["9864791"] = await client.fields.create(newItemTypes["1897306"], {
+    label: "Layout",
+    field_type: "string",
+    api_key: "layout",
+    validators: {
+      required: {},
+      enum: { values: ["default", "narrow", "left", "right"] },
+    },
+    appearance: {
+      addons: [],
+      editor: "single_line",
+      parameters: { heading: false },
+    },
+    default_value: "default",
+  });
+
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Structured text field "Body" (`body`) in block model "Section Structured Text" (`section_structured_text`)'
+  );
+  await client.fields.update("10483125", {
+    validators: {
+      required: {},
+      structured_text_blocks: {
+        item_types: [
+          "41672",
+          "1775016",
+          newItemTypes["1897306"].id,
+          "2040400",
+          "2040401",
+          "2040408",
+        ],
+      },
+      structured_text_links: {
+        on_publish_with_unpublished_references_strategy: "fail",
+        on_reference_unpublish_strategy: "delete_references",
+        on_reference_delete_strategy: "delete_references",
+        item_types: [],
+      },
+    },
+  });
+}

--- a/migrations/1686733385_addStructuredTextImageBlock.ts
+++ b/migrations/1686733385_addStructuredTextImageBlock.ts
@@ -11,7 +11,7 @@ export default async function (client: Client) {
   );
   newItemTypes["1897306"] = await client.itemTypes.create(
     {
-      name: "Structured text image",
+      name: "Structured Text Image",
       api_key: "structured_text_image",
       modular_block: true,
       inverse_relationships_enabled: false,

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -148,6 +148,21 @@
           },
         })
       }
+      case 'StructuredTextImageRecord': {
+        return h(ImageWithCaption, {
+          class: {
+            'structured-text__image-with-caption': true,
+            'structured-text__image-with-caption--narrow': record.layout === 'narrow',
+            'structured-text__image-with-caption--left': record.layout === 'left',
+            'structured-text__image-with-caption--right': record.layout === 'right',
+          },
+          caption: record.caption,
+          image: {
+            ...record.image,
+            sizes: '(min-width: 1100px) 860px, (min-width: 720px) 75vw, 90vw',
+          },
+        })
+      }
       default: {
         return null
       }
@@ -175,8 +190,6 @@
   .structured-text {
     grid-column: var(--grid-content);
     word-wrap: break-word;
-    display: flex;
-    flex-direction: column;
   }
 
   @media (min-width: 720px) {
@@ -249,12 +262,65 @@
   }
 
   .structured-text__blue-text--center .structured-text__buttons-list {
-    align-self: center;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .structured-text__image-with-caption {
     margin: var(--spacing-big) 0;
   }
+
+
+  @media (max-width: 719px) {
+    .structured-text__image-with-caption--left + .structured-text__image-with-caption--right {
+      margin-top: var(--spacing-small)
+    }
+  }
+
+  @media (min-width: 720px) {
+    .structured-text__image-with-caption--narrow {
+      margin-left: auto;
+      margin-right: auto;
+      max-width: 80%
+    }
+
+    .structured-text__image-with-caption--left,
+    .structured-text__image-with-caption--right {
+      width: 50%;
+    }
+
+    .structured-text__image-with-caption--left {
+      padding-right: var(--spacing-small);
+      float: left;
+    }
+
+    .structured-text__image-with-caption--right {
+      padding-left: var(--spacing-small);
+      float: right;
+    }
+
+    .structured-text__image-with-caption--left:has(+ *:not(.structured-text__image-with-caption--right)) {
+      margin-top: 0;
+    }
+
+    /* When combining the selector with the :has selecotor, this selector doesn't work anymore in unsupported browsers  */
+    :not(.structured-text__image-with-caption--left) + .structured-text__image-with-caption--right {
+      margin-top: 0;
+    }
+
+    .structured-text__image-with-caption--left:has(+ *:not(.structured-text__image-with-caption--right)) {
+      margin-right: var(--spacing-small);
+    }
+
+    :not(.structured-text__image-with-caption--left) + .structured-text__image-with-caption--right {
+      margin-left: var(--spacing-small);
+    }
+
+    .structured-text__image-with-caption--left + .structured-text__image-with-caption--right + * {
+      clear: both;
+    }
+  }
+
 
   .structured-text__highlighted-list-item {
     padding: var(--spacing-medium);

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'migrate-lustrum-work-at-pages-to-landing-pages-deploy';
+export const datocmsEnvironment = 'structured-text-image-block-configurable-width';

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -137,6 +137,14 @@ query LandingPage($locale: SiteLocale, $slug: String) {
                 ...image
               }
             }
+            ... on StructuredTextImageRecord {
+              id
+              caption
+              layout
+              image {
+                ...image
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## What changes were made

- Add structured text image with layout option

## How to test or check results

I've added some test images on /en/impact/digital-products-accessible-for-everyone

## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [ ] Appointed PR reviewers

## Todo after merge (in separate PR):

- Switch current `image` block usages in structured text to the new block
- Remove `image` from being used in structured text section