### PR TITLE
Refactor/clean up dato model names and blocks

### DIFF
--- a/migrations/1686746042_renameLandingPageModelAndBlocks.ts
+++ b/migrations/1686746042_renameLandingPageModelAndBlocks.ts
@@ -1,0 +1,79 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Modular content field "Items" (`items`) in block model "Section Timeline" (`section_timeline`)'
+  );
+  await client.fields.update("7518100", {
+    appearance: {
+      addons: [],
+      editor: "rich_text",
+      parameters: { start_collapsed: true },
+    },
+  });
+
+  console.log(
+    'Update Modular content field "Items" (`items`) in block model "Section Image Card Grid" (`section_image_card_grid`)'
+  );
+  await client.fields.update("9103270", {
+    appearance: {
+      addons: [],
+      editor: "rich_text",
+      parameters: { start_collapsed: true },
+    },
+  });
+
+  console.log(
+    'Update Modular content field "Items" (`items`) in block model "Tag list" (`structured_text_tag_list`)'
+  );
+  await client.fields.update("9190211", {
+    appearance: {
+      addons: [],
+      editor: "rich_text",
+      parameters: { start_collapsed: true },
+    },
+  });
+
+  console.log(
+    'Update Modular content field "Items" (`items`) in block model "Section Image Grid" (`section_image_grid`)'
+  );
+  await client.fields.update("10463441", {
+    appearance: {
+      addons: [],
+      editor: "rich_text",
+      parameters: { start_collapsed: true },
+    },
+  });
+
+  console.log("Finalize models/block models");
+
+  console.log('Update block model "Tag list" (`structured_text_tag_list`)');
+  await client.itemTypes.update("1775016", { name: "Tag list" });
+
+  console.log('Update model "Page" (`page`)');
+  await client.itemTypes.update("2035421", {
+    name: "Page",
+    api_key: "page",
+    collection_appearance: "compact",
+  });
+
+  console.log('Update block model "Blue Text" (`structured_text_blue_text`)');
+  await client.itemTypes.update("2040400", { name: "Blue Text" });
+
+  console.log(
+    'Update block model "Highlighted List" (`structured_text_highlighted_list`)'
+  );
+  await client.itemTypes.update("2040401", { name: "Highlighted List" });
+
+  console.log(
+    'Update block model "Highlighted List Item" (`structured_text_highlighted_list_item`)'
+  );
+  await client.itemTypes.update("2040402", { name: "Highlighted List Item" });
+
+  console.log(
+    'Update block model "Buttons List" (`structured_text_buttons_list`)'
+  );
+  await client.itemTypes.update("2040408", { name: "Buttons List" });
+}

--- a/src/composables/useDatoNuxtRoute.ts
+++ b/src/composables/useDatoNuxtRoute.ts
@@ -10,7 +10,7 @@ export function useDatoNuxtRoute() {
     const sharedParams = { language: $i18n.locale() }
 
     switch (page.__typename) {
-      case 'LandingPageRecord': {
+      case 'PageRecord': {
         return { name: 'language-slug', params: { ...sharedParams, slug: page.slug?.split('/') } }
       }
       case 'BlogPostOverviewRecord': {

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'rename-landing-page-and-block-titles';
+export const datocmsEnvironment = 'rename-landing-page-and-block-titles-deploy';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,1 +1,1 @@
-export const datocmsEnvironment = 'migrate-lustrum-work-at-pages-to-landing-pages-deploy';
+export const datocmsEnvironment = 'rename-landing-page-and-block-titles';

--- a/src/layouts/default.query.graphql
+++ b/src/layouts/default.query.graphql
@@ -41,7 +41,7 @@ fragment internalLink on InternalLinkRecord {
   title
   link {
     __typename
-    ... on LandingPageRecord {
+    ... on PageRecord {
       slug
     }
     ... on BlogPostRecord {

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -1,5 +1,5 @@
-query LandingPage($locale: SiteLocale, $slug: String) {
-  page: landingPage(locale: $locale, filter: {slug: {eq: $slug}}) {
+query Page($locale: SiteLocale, $slug: String) {
+  page: page(locale: $locale, filter: {slug: {eq: $slug}}) {
     title
     slug
     social {
@@ -250,7 +250,7 @@ fragment link on RecordInterface {
     title
     link {
       __typename
-      ... on LandingPageRecord {
+      ... on PageRecord {
         slug
       }
       ... on BlogPostRecord {

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -149,7 +149,7 @@ fragment link on RecordInterface {
     title
     link {
       __typename
-      ... on LandingPageRecord {
+      ... on PageRecord {
         slug
       }
       ... on BlogPostRecord {

--- a/src/pages/[language]/blog/page/index.query.graphql
+++ b/src/pages/[language]/blog/page/index.query.graphql
@@ -88,7 +88,7 @@ fragment link on RecordInterface {
     title
     link {
       __typename
-      ... on LandingPageRecord {
+      ... on PageRecord {
         slug
       }
       ... on BlogPostRecord {

--- a/src/pages/[language]/cases/[slug]/index.query.graphql
+++ b/src/pages/[language]/cases/[slug]/index.query.graphql
@@ -178,7 +178,7 @@ fragment link on RecordInterface {
     title
     link {
       __typename
-      ... on LandingPageRecord {
+      ... on PageRecord {
         slug
       }
       ... on BlogPostRecord {

--- a/src/pages/[language]/cases/index.query.graphql
+++ b/src/pages/[language]/cases/index.query.graphql
@@ -42,7 +42,7 @@ fragment page on CaseOverviewRecord {
             id
             title
             link {
-              ... on LandingPageRecord {
+              ... on PageRecord {
                 slug
               }
             }
@@ -127,7 +127,7 @@ fragment link on RecordInterface {
     title
     link {
       __typename
-      ... on LandingPageRecord {
+      ... on PageRecord {
         slug
       }
       ... on BlogPostRecord {

--- a/src/pages/[language]/contact/[slug]/index.query.graphql
+++ b/src/pages/[language]/contact/[slug]/index.query.graphql
@@ -54,7 +54,7 @@ fragment link on RecordInterface {
     title
     link {
       __typename
-      ... on LandingPageRecord {
+      ... on PageRecord {
         slug
       }
       ... on BlogPostRecord {

--- a/src/pages/[language]/index.query.graphql
+++ b/src/pages/[language]/index.query.graphql
@@ -142,7 +142,7 @@ fragment link on RecordInterface {
     title
     link {
       __typename
-      ... on LandingPageRecord {
+      ... on PageRecord {
         slug
       }
       ... on BlogPostRecord {

--- a/src/pages/[language]/services/[slug]/index.query.graphql
+++ b/src/pages/[language]/services/[slug]/index.query.graphql
@@ -150,7 +150,7 @@ fragment link on RecordInterface {
     title
     link {
       __typename
-      ... on LandingPageRecord {
+      ... on PageRecord {
         slug
       }
       ... on BlogPostRecord {

--- a/src/pages/[language]/services/index.query.graphql
+++ b/src/pages/[language]/services/index.query.graphql
@@ -60,7 +60,7 @@ fragment servicespage on ServiceOverviewRecord {
             id
             title
             link {
-              ... on LandingPageRecord {
+              ... on PageRecord {
                 slug
               }
             }
@@ -124,7 +124,7 @@ fragment link on RecordInterface {
     title
     link {
       __typename
-      ... on LandingPageRecord {
+      ... on PageRecord {
         slug
       }
       ... on BlogPostRecord {

--- a/src/scripts/fetch-routes.ts
+++ b/src/scripts/fetch-routes.ts
@@ -57,7 +57,7 @@ const dynamicRoutesConfig: RouteConfig[] = [
     path: "/jobs/",
   },
   {
-    queryOperation: "allLandingPages",
+    queryOperation: "allPages",
     path: "/",
   },
 ];


### PR DESCRIPTION
## What changes were made

- Rename landing page to page
- Remove `Structured Text` prefix in structured text blocks (still present in api keys)
- Collapse some cluttered blocks by default

## How to test or check results

- Build still succeeds

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
