### PR TITLE
Do not render empty paragraphs in structured text

### DIFF
--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -74,13 +74,21 @@
       }, children)
     }),
     renderNodeRule(isParagraph, ({ key, children }) => {
+      const validChildren = children.filter((child) => (
+        typeof child === 'string' ? child.trim() : child
+      ));
+
+      if (validChildren.length === 0) {
+        return null;
+      }
+
       return h(
         'p',
         {
           key,
           class: props.paragraphVariant,
         },
-        children
+        validChildren,
       );
     }),
     renderNodeRule(isList, ({ node, key, children }) => {


### PR DESCRIPTION
## What changes were made
Filter out empty children in structured text so there are no empty `<p>`s in the page.

## How to test or check results
Adding some newlines to a structured text fields should not result in empty paragraphs.

<!-- URL or instructions -->

## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [ ] Appointed PR reviewers
