### PR TITLE
Fix for longer texts on image grid on mobile

### DIFF
--- a/src/components/image-grid/image-grid.vue
+++ b/src/components/image-grid/image-grid.vue
@@ -93,7 +93,7 @@ withDefaults(defineProps<Props>(), {
 
   .image-grid__item {
     flex: 0 0 50%;
-    height: 250px;
+    min-height: 250px;
     background-color: var(--bg-pastel);
   }
 


### PR DESCRIPTION
## What changes were made
- Unset the set height for the image grid items on mobile. It does mean that the rows can have different heights on mobile, but I think that looks better than the super tight text.

## How to test or check results
Visit the about us page to see the difference (also the wip accessibility page): https://deploy-preview-700--voorhoede-website.netlify.app/en/about-us/

Before:
![image](https://github.com/voorhoede/voorhoede-website/assets/15196342/10d6b4a4-aba3-49c5-8418-5a3540248ee0)

After:
![image](https://github.com/voorhoede/voorhoede-website/assets/15196342/34ab9339-794c-42a4-ace5-c4d2f29a6029)

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
