### PR TITLE
Fix: right align image grid item content

### DIFF
--- a/src/components/image-card-grid/image-card-grid.vue
+++ b/src/components/image-card-grid/image-card-grid.vue
@@ -97,6 +97,7 @@ withDefaults(defineProps<Props>(), {
 
   .image-card-grid__title {
     margin-bottom: var(--spacing-medium);
+    text-align: center;
   }
 
   .image-card-grid__list {

--- a/src/components/image-card-grid/image-card-grid.vue
+++ b/src/components/image-card-grid/image-card-grid.vue
@@ -96,7 +96,6 @@ withDefaults(defineProps<Props>(), {
   }
 
   .image-card-grid__title {
-    text-align: center;
     margin-bottom: var(--spacing-medium);
   }
 
@@ -111,7 +110,6 @@ withDefaults(defineProps<Props>(), {
     position: relative;
     display: flex;
     flex-direction: column;
-    align-items: center;
     flex-basis: 20rem;
     gap: var(--spacing-small);
     padding: var(--spacing-medium);
@@ -125,6 +123,7 @@ withDefaults(defineProps<Props>(), {
 
   .image-card-grid__image {
     margin-top: calc(-1 * var(--image-offset));
+    align-self: center;
   }
 
   .image-card-grid__link {


### PR DESCRIPTION
## What changes were made
https://trello.com/c/HV5qSTCi/710-left-align-image-card-grid-text
- Align the title of the cards to the left, now only the image is centered

## How to test or check results
Visit the impact page: https://deploy-preview-701--voorhoede-website.netlify.app/en/impact/
Before:
![image](https://github.com/voorhoede/voorhoede-website/assets/15196342/d6fe2d23-231d-47ac-9429-7c19bd28d2b2)

After:
![image](https://github.com/voorhoede/voorhoede-website/assets/15196342/1f9d0af4-a503-47fb-8a83-157362911771)

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
