### PR TITLE
Fix: support linking to Contact page on Dialogue CTA

### DIFF
--- a/src/components/app-button/app-button.vue
+++ b/src/components/app-button/app-button.vue
@@ -24,7 +24,7 @@
     v-else
     :class="rootClass"
     v-bind="$attrs"
-    :to="to"
+    :to="getDatoNuxtRoute(to)"
   >
     <span v-if="primary || small">{{ label }}</span>
     <template v-else>
@@ -35,6 +35,11 @@
 
 <script>
   export default {
+    setup() {
+      const { getDatoNuxtRoute } = useDatoNuxtRoute()
+
+      return { getDatoNuxtRoute }
+    },
     props: {
       label: {
         type: String,

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -307,6 +307,10 @@ fragment link on RecordInterface {
       ... on PersonRecord {
         slug
       }
+      ... on ContactRecord {
+        id
+      }
+
     }
   }
   ... on ExternalLinkRecord {


### PR DESCRIPTION
## What changes were made
- Add ContactRecord to the internal links query. It has no slug, but couldn't leave it empty.
- Use getDatoNuxtRoute on the app-button. Otherwise the `to` with no slug won't work.

## How to test or check results
Scroll to the end of /nl/impact/purposeful-organisations-and-products/ and click on "Plan een afspraak" to go to the contact page.

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
