### PR TITLE
Add Dato route handling to app button

### DIFF
--- a/src/components/app-button/app-button.vue
+++ b/src/components/app-button/app-button.vue
@@ -24,7 +24,7 @@
     v-else
     :class="rootClass"
     v-bind="$attrs"
-    :to="to"
+    :to="to?.__typename ? getDatoNuxtRoute(to) : to"
   >
     <span v-if="primary || small">{{ label }}</span>
     <template v-else>
@@ -35,6 +35,11 @@
 
 <script>
   export default {
+    setup() {
+      const { getDatoNuxtRoute } = useDatoNuxtRoute()
+
+      return { getDatoNuxtRoute }
+    },
     props: {
       label: {
         type: String,

--- a/src/components/app-button/app-button.vue
+++ b/src/components/app-button/app-button.vue
@@ -24,7 +24,7 @@
     v-else
     :class="rootClass"
     v-bind="$attrs"
-    :to="to?.__typename ? getDatoNuxtRoute(to) : to"
+    :to="to?.__typename ? useDatoNuxtRoute(to) : to"
   >
     <span v-if="primary || small">{{ label }}</span>
     <template v-else>
@@ -35,11 +35,6 @@
 
 <script>
   export default {
-    setup() {
-      const { getDatoNuxtRoute } = useDatoNuxtRoute()
-
-      return { getDatoNuxtRoute }
-    },
     props: {
       label: {
         type: String,

--- a/src/components/app-footer/app-footer.vue
+++ b/src/components/app-footer/app-footer.vue
@@ -28,7 +28,7 @@
           >
             <app-link
               class="app-footer__link"
-              :to="getDatoNuxtRoute(link.link)"
+              :to="useDatoNuxtRoute(link.link)"
             >
               {{ link.title }}
             </app-link>
@@ -185,11 +185,6 @@
 <script>
 
 export default {
-  setup() {
-    const { getDatoNuxtRoute } = useDatoNuxtRoute()
-
-    return { getDatoNuxtRoute }
-  },
   props: {
     links: { type: Object, required: true },
     app: { type: Object, required: true },

--- a/src/components/app-header/app-header.vue
+++ b/src/components/app-header/app-header.vue
@@ -22,7 +22,7 @@
           >
             <app-link
               class="app-header__link"
-              :to="getDatoNuxtRoute(link.link)"
+              :to="useDatoNuxtRoute(link.link)"
             >
               {{ link.title }}
             </app-link>
@@ -34,7 +34,7 @@
             <app-button
               small
               :label="callToAction.title"
-              :to="getDatoNuxtRoute(callToAction.link)"
+              :to="useDatoNuxtRoute(callToAction.link)"
             />
           </li>
         </ul>
@@ -46,11 +46,6 @@
 
 <script>
   export default {
-    setup() {
-      const { getDatoNuxtRoute } = useDatoNuxtRoute()
-
-      return { getDatoNuxtRoute }
-    },
     props: {
       links: {
         type: Array,

--- a/src/components/app-mobile-menu/app-mobile-menu.vue
+++ b/src/components/app-mobile-menu/app-mobile-menu.vue
@@ -44,7 +44,7 @@
         >
           <app-link
             class="h3"
-            :to="getDatoNuxtRoute(link.link)"
+            :to="useDatoNuxtRoute(link.link)"
           >
             {{ link.title }}
           </app-link>
@@ -72,11 +72,6 @@
 
 <script>
   export default {
-    setup() {
-      const { getDatoNuxtRoute } = useDatoNuxtRoute()
-
-      return { getDatoNuxtRoute }
-    },
     props: {
       isOpen: {
         type: Boolean,

--- a/src/components/image-card-grid/image-card-grid.vue
+++ b/src/components/image-card-grid/image-card-grid.vue
@@ -45,7 +45,7 @@
           v-if="card.links[0]?.__typename === 'InternalLinkRecord'"
           class="image-card-grid__link"
           :label="card.links[0].title"
-          :to="getDatoNuxtRoute(card.links[0].link)"
+          :to="useDatoNuxtRoute(card.links[0].link)"
           secondary
         />
       </li>
@@ -55,8 +55,6 @@
 
 <script setup lang="ts">
 import { BackgroundColor } from '../../types/index.d'
-
-const { getDatoNuxtRoute } = useDatoNuxtRoute()
 
 type Props = {
   title: string

--- a/src/components/pivot-list/pivot-list.vue
+++ b/src/components/pivot-list/pivot-list.vue
@@ -54,7 +54,7 @@
           <app-button
             v-else-if="pivot.links[0]?.__typename === 'InternalLinkRecord'"
             :label="pivot.links[0].title"
-            :to="getDatoNuxtRoute(pivot.links[0].link)"
+            :to="useDatoNuxtRoute(pivot.links[0].link)"
           />
 
           <newsletter-form
@@ -68,11 +68,6 @@
 
 <script>
   export default {
-    setup() {
-      const { getDatoNuxtRoute } = useDatoNuxtRoute()
-
-      return { getDatoNuxtRoute }
-    },
     props: {
       pivots: {
         type: Array,

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -31,8 +31,6 @@
   import StructuredTextBlock from './structured-text-block.vue'
   import TwoColumnBlock from '../two-column-block/two-column-block.vue';
 
-  const { getDatoNuxtRoute } = useDatoNuxtRoute()
-
   const props = defineProps({
     content: {
       type: Object,
@@ -136,7 +134,7 @@
           return h(AppButton, {
             key: button.id,
             label: button.title,
-            to: button.url || getDatoNuxtRoute(button.link),
+            to: button.url || useDatoNuxtRoute(button.link),
             external: button.__typename === 'ExternalLinkRecord',
           })
         }))

--- a/src/composables/useDatoNuxtRoute.ts
+++ b/src/composables/useDatoNuxtRoute.ts
@@ -3,60 +3,56 @@ type Page = {
   slug?: string
 }
 
-export function useDatoNuxtRoute() {
+export function useDatoNuxtRoute(page: Page) {
   const { $i18n } = useNuxtApp()
 
-  function getDatoNuxtRoute(page: Page) {
-    const sharedParams = { language: $i18n.locale() }
+  const sharedParams = { language: $i18n.locale() }
 
-    switch (page.__typename) {
-      case 'PageRecord': {
-        return { name: 'language-slug', params: { ...sharedParams, slug: page.slug?.split('/') } }
-      }
-      case 'BlogPostOverviewRecord': {
-        return { name: 'language-blog-page-page', params: { ...sharedParams, page: 1 } }
-      }
-      case 'BlogPostRecord': {
-        return { name: 'language-blog-slug', params: { ...sharedParams, slug: page.slug } }
-      }
-      case 'CaseOverviewRecord': {
-        return { name: 'language-cases', params: sharedParams }
-      }
-      case 'CaseItemRecord': {
-        return { name: 'language-cases-slug', params: { ...sharedParams, slug: page.slug } }
-      }
-      case 'ContactRecord': {
-        return { name: 'language-contact', params: sharedParams }
-      }
-      case 'EventOverviewRecord': {
-        return { name: 'language-events', params: sharedParams }
-      }
-      case 'EventItemRecord': {
-        return { name: 'language-events-slug', params: { ...sharedParams, slug: page.slug } }
-      }
-      case 'FaqRecord': {
-        return { name: 'language-faq', params: sharedParams }
-      }
-      case 'JobRecord': {
-        return { name: 'language-jobs-slug', params: { ...sharedParams, slug: page.slug } }
-      }
-      case 'LustrumRecord': {
-        return { name: 'language-lustrum', params: sharedParams }
-      }
-      case 'ServiceOverviewRecord': {
-        return { name: 'language-services', params: sharedParams }
-      }
-      case 'ServiceRecord': {
-        return { name: 'language-services-slug', params: { ...sharedParams, slug: page.slug } }
-      }
-      case 'PersonRecord': {
-        return { name: 'language-team-slug', params: { ...sharedParams, slug: page.slug } }
-      }
-      case 'WorkatRecord': {
-        return { name: 'language-work-at', params: sharedParams }
-      }
+  switch (page.__typename) {
+    case 'PageRecord': {
+      return { name: 'language-slug', params: { ...sharedParams, slug: page.slug?.split('/') } }
+    }
+    case 'BlogPostOverviewRecord': {
+      return { name: 'language-blog-page-page', params: { ...sharedParams, page: 1 } }
+    }
+    case 'BlogPostRecord': {
+      return { name: 'language-blog-slug', params: { ...sharedParams, slug: page.slug } }
+    }
+    case 'CaseOverviewRecord': {
+      return { name: 'language-cases', params: sharedParams }
+    }
+    case 'CaseItemRecord': {
+      return { name: 'language-cases-slug', params: { ...sharedParams, slug: page.slug } }
+    }
+    case 'ContactRecord': {
+      return { name: 'language-contact', params: sharedParams }
+    }
+    case 'EventOverviewRecord': {
+      return { name: 'language-events', params: sharedParams }
+    }
+    case 'EventItemRecord': {
+      return { name: 'language-events-slug', params: { ...sharedParams, slug: page.slug } }
+    }
+    case 'FaqRecord': {
+      return { name: 'language-faq', params: sharedParams }
+    }
+    case 'JobRecord': {
+      return { name: 'language-jobs-slug', params: { ...sharedParams, slug: page.slug } }
+    }
+    case 'LustrumRecord': {
+      return { name: 'language-lustrum', params: sharedParams }
+    }
+    case 'ServiceOverviewRecord': {
+      return { name: 'language-services', params: sharedParams }
+    }
+    case 'ServiceRecord': {
+      return { name: 'language-services-slug', params: { ...sharedParams, slug: page.slug } }
+    }
+    case 'PersonRecord': {
+      return { name: 'language-team-slug', params: { ...sharedParams, slug: page.slug } }
+    }
+    case 'WorkatRecord': {
+      return { name: 'language-work-at', params: sharedParams }
     }
   }
-
-  return { getDatoNuxtRoute }
 }

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -307,6 +307,10 @@ fragment link on RecordInterface {
       ... on PersonRecord {
         slug
       }
+      ... on ContactRecord {
+        id
+      }
+
     }
   }
   ... on ExternalLinkRecord {


### PR DESCRIPTION
## What changes were made
- Add ContactRecord to the internal links query. It has no slug, but couldn't leave it empty.
- Use getDatoNuxtRoute on the app-button. Otherwise the `to` with no slug won't work.

## How to test or check results
Scroll to the end of /nl/impact/purposeful-organisations-and-products/ and click on "Plan een afspraak" to go to the contact page.

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
