### PR TITLE
Improve image quality for team member photos

### DIFF
--- a/src/components/team-gallery/team-gallery.vue
+++ b/src/components/team-gallery/team-gallery.vue
@@ -13,6 +13,7 @@
             :alt="member.name"
             :width="member.image.width"
             :height="member.image.height"
+            :quality="65"
             loading="lazy"
             sizes="(min-width: 800px) 20vw, (min-width: 500px) 33vw, 50vw"
           />


### PR DESCRIPTION
Slightly up the quality of the team member photos, brings a bit more color and less compression artifacts while sacrificing a little bit of the image size. Because these pictures are pretty big and close up I think it's worth it.