### PR TITLE
Use same quality of 75 for all "close-up" face images

### DIFF
--- a/src/components/blog-author/blog-author.vue
+++ b/src/components/blog-author/blog-author.vue
@@ -14,6 +14,7 @@
         :height="135"
         loading="eager"
         :modifiers="{ ar: '1:1', fit: 'crop', crop: 'faces' }"
+        :quality="75"
       />
     </app-link>
     <div class="blog-author__text body">

--- a/src/components/blog-list-item/blog-list-item.vue
+++ b/src/components/blog-list-item/blog-list-item.vue
@@ -40,7 +40,7 @@
           :width="large ? 65 : 40"
           :height="large ? 65 : 40"
           loading="lazy"
-          :quality="85"
+          :quality="75"
           :modifiers="{ ar: '1:1', fit: 'crop', crop: 'faces', sat: -100 }"
         />
       </div>

--- a/src/components/contact-form/contact-form.vue
+++ b/src/components/contact-form/contact-form.vue
@@ -24,6 +24,7 @@
           :width="144"
           :height="170"
           loading="lazy"
+          :quality="75"
         />
         <p class="h5">
           {{ contactPerson.name }} {{ contactPerson.lastName }}

--- a/src/components/team-gallery/team-gallery.vue
+++ b/src/components/team-gallery/team-gallery.vue
@@ -13,7 +13,7 @@
             :alt="member.name"
             :width="member.image.width"
             :height="member.image.height"
-            :quality="65"
+            :quality="75"
             loading="lazy"
             sizes="(min-width: 800px) 20vw, (min-width: 500px) 33vw, 50vw"
           />


### PR DESCRIPTION
## What changes were made
Using a slightly higher quality of 75 removes compression artifacts
while only growing the image size by about 1kB - 3Kb.

Also think it's good to be consistent since these are similar photos.

## How to test or check results
See contact form photo, blog photos & team gallery.

## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [ ] Appointed PR reviewers
