### PR TITLE
Feat/prettier blog pagination routing

### DIFF
--- a/src/components/pagination-nav/pagination-nav.vue
+++ b/src/components/pagination-nav/pagination-nav.vue
@@ -67,7 +67,7 @@
     currentPage: number
     perPage: number
     // eslint-disable-next-line no-unused-vars
-    getPaginatedRoute: (page: number) => number | RouteLocation
+    getPaginatedRoute: (page: number) => RouteLocation
   }>()
 
   const totalPages = computed(() => Math.ceil(props.totalItems / props.perPage))

--- a/src/components/pagination-nav/pagination-nav.vue
+++ b/src/components/pagination-nav/pagination-nav.vue
@@ -6,7 +6,7 @@
       <li class="pagination-nav__item">
         <app-link
           v-if="props.currentPage > 1"
-          :to="toLink(previousPage)"
+          :to="getPaginatedRoute(previousPage)"
           :aria-label="$t('previous_page')"
         >
           &lt; {{ $t('previous') }}
@@ -22,7 +22,7 @@
       >
         <app-link
           v-if="page === props.currentPage"
-          :to="toLink(page)"
+          :to="getPaginatedRoute(page)"
           :aria-label="$t('current_page', { page })"
           aria-current="true"
         >
@@ -30,7 +30,7 @@
         </app-link>
         <app-link
           v-else-if="page !== DOTS"
-          :to="toLink(page)"
+          :to="getPaginatedRoute(page)"
           :aria-label="$t('go_to_page', { page })"
         >
           {{ page }}
@@ -46,7 +46,7 @@
       <li class="pagination-nav__item">
         <app-link
           v-if="props.currentPage < totalPages"
-          :to="toLink(nextPage)"
+          :to="getPaginatedRoute(nextPage)"
           :aria-label="$t('next_page')"
         >
           {{ $t('next') }} >
@@ -56,27 +56,19 @@
   </nav>
 </template>
 
-<script setup>
+<script setup lang="ts">
+  import { RouteLocation } from "vue-router";
+
+
   const DOTS = '...'
 
-  const props = defineProps({
-    totalItems: {
-      type: Number,
-      required: true,
-    },
-    currentPage: {
-      type: Number,
-      required: true,
-    },
-    perPage: {
-      type: Number,
-      required: true,
-    },
-    scrollTo: {
-      type: String,
-      default: null,
-    },
-  })
+  const props = defineProps<{
+    totalItems: number
+    currentPage: number
+    perPage: number
+    // eslint-disable-next-line no-unused-vars
+    getPaginatedRoute: (page: number) => number | RouteLocation
+  }>()
 
   const totalPages = computed(() => Math.ceil(props.totalItems / props.perPage))
   const previousPage = computed(() => props.currentPage - 1)
@@ -146,13 +138,9 @@
     }
   })
 
-  function range(start, end) {
+  function range(start: number, end: number) {
     const size = end - start + 1
     return [...Array(size).keys()].map(i => i + start)
-  }
-
-  function toLink(page) {
-    return { params: { page }, ...(props.scrollTo && { hash: props.scrollTo })}
   }
 </script>
 

--- a/src/composables/useDatoNuxtRoute.ts
+++ b/src/composables/useDatoNuxtRoute.ts
@@ -13,7 +13,7 @@ export function useDatoNuxtRoute(page: Page) {
       return { name: 'language-slug', params: { ...sharedParams, slug: page.slug?.split('/') } }
     }
     case 'BlogPostOverviewRecord': {
-      return { name: 'language-blog-page-page', params: { ...sharedParams, page: 1 } }
+      return { name: 'language-blog' }
     }
     case 'BlogPostRecord': {
       return { name: 'language-blog-slug', params: { ...sharedParams, slug: page.slug } }

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -155,7 +155,7 @@
     >
       <app-link
         class="app-button app-button--secondary body font-bold"
-        :to="$localeUrl({ name: 'blog-page-page', params: { page: 1 } })"
+        :to="$localeUrl({ name: 'blog' })"
       >
         &larr; {{ $t('all_blogposts') }}
       </app-link>

--- a/src/pages/[language]/blog/index.vue
+++ b/src/pages/[language]/blog/index.vue
@@ -1,10 +1,3 @@
-<script setup>
-definePageMeta({
-  middleware: [
-    // eslint-disable-next-line no-unused-vars
-    function (to, from) {
-      return navigateTo({ name: 'language-blog-page-page', params: { page: 1 }})
-    },
-  ],
-});
+<script>
+export { default } from './page/[page].vue'
 </script>

--- a/src/pages/[language]/blog/page/[page].vue
+++ b/src/pages/[language]/blog/page/[page].vue
@@ -56,6 +56,16 @@
 
   const { $localeUrl } = useNuxtApp();
 
+  definePageMeta({
+    middleware: [
+      function (to) {
+        if (to.params.page === '1') {
+          return navigateTo({ name: 'language-blog' })
+        }
+      },
+    ],
+  });
+
   // If you change this, also change it in fetch-routes.ts
   const PER_PAGE = 20;
 

--- a/src/pages/[language]/blog/page/[page].vue
+++ b/src/pages/[language]/blog/page/[page].vue
@@ -31,7 +31,7 @@
         :total-items="data.itemsMeta.count"
         :current-page="currentPage"
         :per-page="PER_PAGE"
-        :scroll-to="`#${SECTION_ID}`"
+        :get-paginated-route="getPaginatedRoute"
         class="page-blog__pagination"
       />
     </section>
@@ -53,6 +53,8 @@
 
 <script setup>
   import query from './index.query.graphql?raw';
+
+  const { $localeUrl } = useNuxtApp();
 
   // If you change this, also change it in fetch-routes.ts
   const PER_PAGE = 20;
@@ -87,6 +89,14 @@
   }
 
   useSeoHead(data.value.page);
+
+  function getPaginatedRoute(pageNumber) {
+    if (pageNumber === 1) {
+      return $localeUrl({ name: 'blog', hash: `#${SECTION_ID}` });
+    } else {
+      return $localeUrl({ name: 'blog-page-page', params: { page: pageNumber }, hash: `#${SECTION_ID}` });
+    }
+  }
 </script>
 
 <style>

--- a/src/plugins/localeUrl.ts
+++ b/src/plugins/localeUrl.ts
@@ -1,13 +1,14 @@
 export default defineNuxtPlugin((nuxtApp) => {
   return {
     provide: {
-      localeUrl: ({ name = '', params = {} } = {}) => {
+      localeUrl: ({ name = '', params = {}, ...other } = {}) => {
         return {
           name: ['language', name].filter(Boolean).join('-'),
           params: {
             language: nuxtApp.$i18n.locale(),
             ...params,
           },
+          ...other
         };
       },
     },

--- a/src/scripts/fetch-routes.ts
+++ b/src/scripts/fetch-routes.ts
@@ -67,7 +67,10 @@ const fetchBlogPagesRoutes = async ({ locale } : { locale: string }) => {
   const { data: meta } = await fetchMetaForOperation({ operation, locale });
   const { count } = meta[`_${operation}Meta`];
   const pages = Math.ceil(count / BLOG_PER_PAGE);
-  return  [...Array(pages)].map((_, index) => `/${locale}/blog/page/${index + 1}/`);
+  return [...Array(pages)]
+    .map((_, index) => index + 1)
+    .filter(pageNumber => pageNumber > 1)
+    .map((pageNumber) => `/${locale}/blog/page/${pageNumber}/`);
 };
 
 // fetches a paginated list of slugs for a given operation


### PR DESCRIPTION
## What changes were made

- Use the naked /blog route for page 1, while using blog/page/x for other page numbers
- Refactor `pagination-nav` to be more context independent. It now should be useable for any page, no matter the route structure.

## How to test or check results

- Check the blog overview routes
- Navigating to /blog/page/1 should result in a redirect to the naked url

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
