### PR TITLE
Migrate generic text to structured text on Jobs

### DIFF
--- a/migrations/1689235858_allowStructuredTextOnJobsPage.ts
+++ b/migrations/1689235858_allowStructuredTextOnJobsPage.ts
@@ -1,0 +1,12 @@
+import { Client } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log(
+    'Update Modular content field "Job content" (`job_content`) in model "Job" (`job`)'
+  );
+  await client.fields.update("182802", {
+    validators: {
+      rich_text_blocks: { item_types: ["41836", "1992764", "2040351"] },
+    },
+  });
+}

--- a/migrations/1689235859_convertGenericTextToStructuredTextOnJobsPage.ts
+++ b/migrations/1689235859_convertGenericTextToStructuredTextOnJobsPage.ts
@@ -1,0 +1,52 @@
+import { Client, buildBlockRecord } from '@datocms/cli/lib/cma-client-node';
+import { parse } from 'parse5'
+import { parse5ToStructuredText } from 'datocms-html-to-structured-text'
+
+export default async function(client: Client): Promise<void> {
+  for await (const page of client.items.listPagedIterator({
+    filter: { type: 'job' },
+    version: 'current',
+    nested: true
+  })) {
+    const pageBlocks = page.job_content
+    const genericTextBlock = await client.itemTypes.find('generic_text_block')
+    const structuredTextSection = await client.itemTypes.find('section_structured_text')
+
+    const updatedPageBlocks = Object.fromEntries(
+      await Promise.all(
+        Object.keys(pageBlocks).map(async locale => {
+          const pageBlocksForLocale = pageBlocks[locale]
+          const updatedPageBlocksForLocale = await Promise.all(pageBlocksForLocale.map(async (block) => {
+            if (block.relationships.item_type.data.id !== genericTextBlock.id) {
+              return block
+            }
+
+            let html = block.attributes.title ? `<h2>${block.attributes.title}</h2>\n` : ''
+            html += block.attributes.body
+
+            const structuredTextContent = await parse5ToStructuredText(parse(html), {
+              allowedHeadingLevels: [2],
+              allowedMarks: ['strong', 'emphasis'],
+              allowedBlocks: ['heading', 'blockquote', 'list', 'link'],
+            });
+
+            return buildBlockRecord({
+              item_type: { type: 'item_type', id: structuredTextSection.id },
+              body: structuredTextContent
+            })
+          }))
+
+          return [locale, updatedPageBlocksForLocale]
+        })
+      )
+    )
+
+    await client.items.update(page.id, {
+      job_content: updatedPageBlocks
+    });
+
+    if (page.meta.status !== 'draft') {
+      await client.items.publish(page.id);
+    }
+  }
+}

--- a/migrations/1689237807_deleteGenericTextBlock.ts
+++ b/migrations/1689237807_deleteGenericTextBlock.ts
@@ -9,4 +9,9 @@ export default async function (client: Client) {
   await client.fields.update("182802", {
     validators: { rich_text_blocks: { item_types: ["1992764", "2040351"] } },
   });
+
+  console.log("Destroy models/block models");
+
+  console.log('Delete block model "Generic text block" (`generic_text_block`)');
+  await client.itemTypes.destroy("41836", { skip_menu_items_deletion: true });
 }

--- a/migrations/1689237807_removeGenericTextFromJobsPage.ts
+++ b/migrations/1689237807_removeGenericTextFromJobsPage.ts
@@ -1,0 +1,12 @@
+import { Client } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Modular content field "Job content" (`job_content`) in model "Job" (`job`)'
+  );
+  await client.fields.update("182802", {
+    validators: { rich_text_blocks: { item_types: ["1992764", "2040351"] } },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,12 @@
       "devDependencies": {
         "@datocms/cli": "^1.1.9",
         "@typescript-eslint/parser": "^5.60.0",
+        "datocms-html-to-structured-text": "^2.1.11",
         "eslint": "^8.43.0",
         "eslint-plugin-vue": "^9.15.1",
         "husky": "^8.0.3",
         "nano-staged": "^0.8.0",
+        "parse5": "^7.1.2",
         "typescript-imgix-url-params": "^0.3.1"
       },
       "engines": {
@@ -2345,6 +2347,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
       "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.5.tgz",
+      "integrity": "sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -2373,6 +2384,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.1.0.tgz",
       "integrity": "sha512-O+z53uwx64xY7D6roOi4+jApDGFg0qn6WHcxe5QeqjMaTezBO/mxdfFXIVAVVyNWKx84OmPB3L8kbVYOTeN34A=="
     },
+    "node_modules/@types/parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
+      "dev": true
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -2386,6 +2403,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.60.0",
@@ -3740,6 +3763,16 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -3872,6 +3905,12 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==",
+      "dev": true
     },
     "node_modules/css-tree": {
       "version": "2.3.1",
@@ -4025,6 +4064,24 @@
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/datocms-html-to-structured-text": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/datocms-html-to-structured-text/-/datocms-html-to-structured-text-2.1.11.tgz",
+      "integrity": "sha512-qGx3w5iDcaiK4WrHkbhPWGEhPAzk/p5vq11O2YYxpiZWzaRjKE9AJhcqV4dm5fmeMm7cR2ylm2+PNyZT4M1Zhw==",
+      "dev": true,
+      "dependencies": {
+        "datocms-structured-text-utils": "^2.0.4",
+        "extend": "^3.0.2",
+        "hast-util-from-dom": "^3.0.0",
+        "hast-util-from-parse5": "^6.0.1",
+        "hast-util-has-property": "^1.0.4",
+        "hast-util-is-element": "^1.1.0",
+        "hast-util-to-text": "^2.0.1",
+        "rehype-minify-whitespace": "^4.0.5",
+        "unist-util-is": "^4.0.4",
+        "unist-utils-core": "^1.0.5"
       }
     },
     "node_modules/datocms-listen": {
@@ -4729,6 +4786,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -5395,6 +5458,123 @@
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
       "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
     },
+    "node_modules/hast-util-embedded": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-1.0.6.tgz",
+      "integrity": "sha512-JQMW+TJe0UAIXZMjCJ4Wf6ayDV9Yv3PBDPsHD4ExBpAspJ6MOcCX+nzVF+UJVv7OqPcg852WEMSHQPoRA+FVSw==",
+      "dev": true,
+      "dependencies": {
+        "hast-util-is-element": "^1.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-3.0.0.tgz",
+      "integrity": "sha512-4vQuGiD5Y/wlD7fZiY4mZML/6oh0GOnH38UNyeDFcSTE4AHF0zjKHZfbd+ekVwPvsZXRl8choc99INHUwSPJlg==",
+      "dev": true,
+      "dependencies": {
+        "hastscript": "^6.0.0",
+        "web-namespaces": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-6.0.1.tgz",
+      "integrity": "sha512-jeJUWiN5pSxW12Rh01smtVkZgZr33wBokLzKLwinYOUfSzm1Nl/c3GUGebDyOKjdsRgMvoVbV0VpAcpjF4NrJA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse5": "^5.0.0",
+        "hastscript": "^6.0.0",
+        "property-information": "^5.0.0",
+        "vfile": "^4.0.0",
+        "vfile-location": "^3.2.0",
+        "web-namespaces": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
+      "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
+      "integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-2.0.1.tgz",
+      "integrity": "sha512-8nsgCARfs6VkwH2jJU9b8LNTuR4700na+0h3PqCaEk4MAnMDeu5P0tP8mjk9LLNGxIeQRLbiDbZVw6rku+pYsQ==",
+      "dev": true,
+      "dependencies": {
+        "hast-util-is-element": "^1.0.0",
+        "repeat-string": "^1.0.0",
+        "unist-util-find-after": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
+      "integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -5774,6 +5954,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-builtin-module": {
@@ -6825,6 +7028,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/not": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/not/-/not-0.1.0.tgz",
+      "integrity": "sha512-5PDmaAsVfnWUgTUbJ3ERwn7u79Z0dYxN9ErxCpVJJqe2RK0PJ3z+iFUxuqjwtlDDegXvtWoxD/3Fzxox7tFGWA==",
+      "dev": true
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -7384,6 +7593,18 @@
       "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
       "dependencies": {
         "parse-path": "^7.0.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -8156,6 +8377,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/protocols": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
@@ -8358,6 +8592,31 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-4.0.5.tgz",
+      "integrity": "sha512-QC3Z+bZ5wbv+jGYQewpAAYhXhzuH/TVRx7z08rurBmh9AbG8Nu8oJnvs9LWj43Fd/C7UIhXoQ7Wddgt+ThWK5g==",
+      "dev": true,
+      "dependencies": {
+        "hast-util-embedded": "^1.0.0",
+        "hast-util-is-element": "^1.0.0",
+        "hast-util-whitespace": "^1.0.4",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {
@@ -8773,6 +9032,16 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/sprintf-js": {
@@ -9339,6 +9608,76 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-3.0.0.tgz",
+      "integrity": "sha512-ojlBqfsBftYXExNu3+hHLfJQ/X1jYY/9vdm4yZWjIbf0VuWF6CRufci1ZyoD/wV2TYMKxXUoNuoqwy+CkgzAiQ==",
+      "dev": true,
+      "dependencies": {
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-select": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-3.0.4.tgz",
+      "integrity": "sha512-xf1zCu4okgPqGLdhCDpRnjwBNyv3EqjiXRUbz2SdK1+qnLMB7uXXajfzuBvvbHoQ+JLyp4AEbFCGndmc6S72sw==",
+      "dev": true,
+      "dependencies": {
+        "css-selector-parser": "^1.0.0",
+        "not": "^0.1.0",
+        "nth-check": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-utils-core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unist-utils-core/-/unist-utils-core-1.1.0.tgz",
+      "integrity": "sha512-tYWUpVOwxquKxwixoX46o4Zsd1X/AY1AlviLeubRLBgi4WvTkSPUfzBVthcKLZ6jLNKyXtJz0DYdZFvmyml5ng==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.4.1",
+        "unist-util-is": "^4.1.0",
+        "unist-util-select": "^3.0.4"
+      }
+    },
+    "node_modules/unist-utils-core/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -9517,6 +9856,46 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
+    },
+    "node_modules/vfile": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
+      "integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "4.3.9",
@@ -9845,6 +10224,16 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-namespaces": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -9972,6 +10361,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/xxhashjs": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
@@ -10080,6 +10478,16 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
   "devDependencies": {
     "@datocms/cli": "^1.1.9",
     "@typescript-eslint/parser": "^5.60.0",
+    "datocms-html-to-structured-text": "^2.1.11",
     "eslint": "^8.43.0",
     "eslint-plugin-vue": "^9.15.1",
     "husky": "^8.0.3",
     "nano-staged": "^0.8.0",
+    "parse5": "^7.1.2",
     "typescript-imgix-url-params": "^0.3.1"
   },
   "engines": {

--- a/src/pages/[language]/jobs/[slug].query.graphql
+++ b/src/pages/[language]/jobs/[slug].query.graphql
@@ -27,10 +27,7 @@ fragment job on JobRecord {
     }
   }
   jobImage {
-    url
-    alt
-    width
-    height
+    ...image
   }
   url
   validUntil
@@ -40,29 +37,75 @@ fragment job on JobRecord {
   maxSalary
   jobDescription
   jobContent {
+    __typename
     ... on GalleryBlockRecord {
-      _modelApiKey
       id
       gallery {
         images {
-          id
-          url
-          alt
-          width
-          height
+          ...image
         }
       }
     }
-    ... on GenericTextBlockRecord {
-      _modelApiKey
-      id
-      title
-      body
-      image {
-        url
-        alt
-        width
-        height
+    ...on SectionStructuredTextRecord {
+      gridAlignment
+      body {
+        value
+        blocks {
+          __typename
+          ... on StructuredTextBlueTextRecord {
+            id
+            variant
+            textAlignment
+            body {
+              value
+              blocks {
+                __typename
+                ... on StructuredTextButtonsListRecord {
+                  ...buttonsList
+                }
+              }
+            }
+          }
+          ... on StructuredTextButtonsListRecord {
+            ...buttonsList
+          }
+          ... on StructuredTextHighlightedListRecord {
+            id
+            items {
+              body {
+                value
+              }
+            }
+          }
+          ... on StructuredTextTagListRecord {
+            id
+            items {
+              id
+              amount
+              label
+            }
+          }
+          ... on ImageRecord {
+            id
+            caption
+            captionPosition
+            image {
+              ...image
+            }
+          }
+          ... on StructuredTextImageRecord {
+            ...structuredTextImage
+          }
+          ... on TwoColumnBlockRecord {
+            id
+            leftItems {
+              ...twoColumnItemFragment
+            }
+            rightItems {
+              ...twoColumnItemFragment
+            }
+          }
+        }
       }
     }
   }
@@ -74,5 +117,87 @@ fragment job on JobRecord {
       city
       countryCode
     }
+  }
+}
+
+fragment image on FileField {
+  id
+  url
+  alt
+  width
+  height
+}
+
+fragment buttonsList on StructuredTextButtonsListRecord {
+  id
+  buttons {
+    ...link
+  }
+}
+
+fragment structuredTextImage on StructuredTextImageRecord {
+  id
+  caption
+  image {
+    ...image
+  }
+}
+
+fragment twoColumnItemFragment on RecordInterface {
+  __typename
+  ... on StructuredTextRecord {
+    id
+    body {
+      value
+      blocks {
+        ... on StructuredTextButtonsListRecord {
+          ...buttonsList
+        }
+      }
+    }
+  }
+  ... on StructuredTextImageRecord {
+    ...structuredTextImage
+  }
+}
+
+fragment link on RecordInterface {
+  __typename
+  ... on InternalLinkRecord {
+    id
+    title
+    link {
+      __typename
+      ... on PageRecord {
+        slug
+      }
+      ... on BlogPostRecord {
+        slug
+      }
+      ... on CaseItemRecord {
+        slug
+      }
+      ... on EventItemRecord {
+        slug
+      }
+      ... on JobRecord {
+        slug
+      }
+      ... on ServiceRecord {
+        slug
+      }
+      ... on PersonRecord {
+        slug
+      }
+      ... on ContactRecord {
+        id
+      }
+
+    }
+  }
+  ... on ExternalLinkRecord {
+    id
+    title
+    url
   }
 }

--- a/src/pages/[language]/jobs/[slug].vue
+++ b/src/pages/[language]/jobs/[slug].vue
@@ -24,16 +24,14 @@
 
       <div class="page-job__content">
         <template v-for="item in data.page.jobContent">
-          <generic-text-block
-            v-if="item._modelApiKey === 'generic_text_block'"
+          <structured-text-block
+            v-if="item.__typename === 'SectionStructuredTextRecord'"
             :key="item.id"
-            :is-nested="false"
-            :title="item.title"
-            :body="item.body"
-            :image="item.image"
+            :content="item.body"
+            paragraph-variant="body"
           />
           <gallery-block
-            v-if="item._modelApiKey === 'gallery_block'"
+            v-if="item.__typename === 'GalleryBlockRecord'"
             :key="item.id"
             :images="item.gallery.images"
             class="page-job__gallery"
@@ -196,6 +194,10 @@
       grid-column: var(--grid-content);
       background-color: var(--white);
       padding: var(--spacing-large) var(--spacing-larger);
+    }
+
+    .page-job__content .structured-text {
+      width: 70%;
     }
 
     .page-job__content .scroll-to {

--- a/src/pages/[language]/jobs/[slug].vue
+++ b/src/pages/[language]/jobs/[slug].vue
@@ -28,7 +28,6 @@
             v-if="item.__typename === 'SectionStructuredTextRecord'"
             :key="item.id"
             :content="item.body"
-            paragraph-variant="body"
           />
           <gallery-block
             v-if="item.__typename === 'GalleryBlockRecord'"


### PR DESCRIPTION
Merge after #724 

## What changes were made

- Migrate generic text to structured text on Jobs
- Remove generic text blocks from the Job model

## How to test or check results

/en/jobs/internship/ vs https://www.voorhoede.nl/en/jobs/internship/

The titles are bigger.

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
