### PR TITLE
Feat: Scale the footer's certificate logos.

### DIFF
--- a/src/components/app-footer/app-footer.vue
+++ b/src/components/app-footer/app-footer.vue
@@ -122,8 +122,8 @@
               <dato-image
                 class="app-footer__certificate-logo"
                 :src="certificate.logo.url"
-                :width="80"
-                :height="60"
+                :width="100"
+                :height="75"
                 :alt="certificate.title"
                 loading="lazy"
               />
@@ -397,6 +397,7 @@ export default {
   @media (min-width: 768px) {
     .app-footer__certificate-list {
       justify-content: space-between;
+      margin-top: var(--spacing-tiny);
     }
   }
 


### PR DESCRIPTION
## What changes were made
The footer's certificate logos got scaled up by 25% and the desktop space between the socials and the logos have been increased by a tiny amount. To me, it looks fine on mobile as well, if you find them "too big" I can revert their sizes on mobile.

## How to test or check results

Check the footer :)

## Checks
- [X] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [X] Appointed PR reviewers
