### PR TITLE
Feat: Add cases block to service page.

### DIFF
--- a/migrations/1693569227_addAuthors.ts
+++ b/migrations/1693569227_addAuthors.ts
@@ -6,11 +6,11 @@ export default async function (client: Client) {
 
   console.log("Create new models/block models");
 
-  console.log('Create block model "Section Cases List" (`section_cases_list`)');
+  console.log('Create block model "Cases List" (`cases_list`)');
   newItemTypes["2435781"] = await client.itemTypes.create(
     {
-      name: "Section Cases List",
-      api_key: "section_cases_list",
+      name: "Cases List",
+      api_key: "cases_list",
       modular_block: true,
       inverse_relationships_enabled: false,
     },
@@ -20,7 +20,7 @@ export default async function (client: Client) {
   console.log("Creating new fields/fieldsets");
 
   console.log(
-    'Create Multiple links field "Cases" (`cases`) in block model "Section Cases List" (`section_cases_list`)'
+    'Create Multiple links field "Cases" (`cases`) in block model "Cases List" (`cases_list`)'
   );
   newFields["12754652"] = await client.fields.create(newItemTypes["2435781"], {
     label: "Cases",

--- a/migrations/1693569227_addAuthors.ts
+++ b/migrations/1693569227_addAuthors.ts
@@ -1,0 +1,60 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  const newFields: Record<string, SimpleSchemaTypes.Field> = {};
+  const newItemTypes: Record<string, SimpleSchemaTypes.ItemType> = {};
+
+  console.log("Create new models/block models");
+
+  console.log('Create block model "Section Cases List" (`section_cases_list`)');
+  newItemTypes["2435781"] = await client.itemTypes.create(
+    {
+      name: "Section Cases List",
+      api_key: "section_cases_list",
+      modular_block: true,
+      inverse_relationships_enabled: false,
+    },
+    { skip_menu_item_creation: true }
+  );
+
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create Multiple links field "Cases" (`cases`) in block model "Section Cases List" (`section_cases_list`)'
+  );
+  newFields["12754652"] = await client.fields.create(newItemTypes["2435781"], {
+    label: "Cases",
+    field_type: "links",
+    api_key: "cases",
+    validators: {
+      items_item_type: {
+        on_publish_with_unpublished_references_strategy: "fail",
+        on_reference_unpublish_strategy: "delete_references",
+        on_reference_delete_strategy: "delete_references",
+        item_types: ["38240"],
+      },
+      size: { min: 1 },
+    },
+    appearance: { addons: [], editor: "links_select", parameters: {} },
+  });
+
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Modular content field "Items" (`items`) in model "Service" (`service`)'
+  );
+  await client.fields.update("164064", {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          "41672",
+          "44361",
+          "262363",
+          "316629",
+          "2040351",
+          newItemTypes["2435781"].id,
+        ],
+      },
+    },
+  });
+}

--- a/src/components/cases-list/cases-list.vue
+++ b/src/components/cases-list/cases-list.vue
@@ -1,0 +1,68 @@
+<template>
+  <ul
+    class="cases-list"
+    :class="{'cases-list--three-columns': maxColumns >= 3}"
+  >
+    <li
+      v-for="caseItem in cases"
+      :key="caseItem.slug"
+    >
+      <link-card
+        :internal-link="
+          $localeUrl({ name: 'cases-slug', params: { slug: caseItem.slug } })
+        "
+        :image="caseItem.caseTeaser.image"
+        :title="caseItem.title"
+        :body="caseItem.caseTeaser.title"
+      />
+    </li>
+  </ul>
+</template>
+
+<script>
+  export default {
+    props: {
+      cases: {
+        type: Array,
+        required: true,
+      },
+      maxColumns: {
+        type: Number,
+        validator: (value) => [2, 3].includes(value),
+        default: 3,
+      },
+    },
+  };
+</script>
+
+<style>
+  .cases-list {
+    display: grid;
+    grid-template-columns: 1fr;
+    row-gap: var(--spacing-medium);
+    column-gap: var(--spacing-medium);
+  }
+
+  .cases-list .link-card {
+    height: 100%;
+  }
+
+  @media (min-width: 720px) {
+    .cases-list {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (min-width: 1000px) {
+    .cases-list.cases-list--three-columns {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  @media (min-width: 1200px) {
+    .cases-list {
+      row-gap: var(--spacing-large);
+      column-gap: var(--spacing-large);
+    }
+  }
+</style>

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'service-page-structured-text-deploy';
+export const datocmsEnvironment = 'add-cases-block-to-service-page';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'add-cases-block-to-service-page';
+export const datocmsEnvironment = 'add-cases-block-to-service-page-deploy';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/cases/index.vue
+++ b/src/pages/[language]/cases/index.vue
@@ -36,19 +36,7 @@
       <h2 class="h2 page-cases__overview-title">
         {{ $t('all_cases') }}
       </h2>
-      <ul class="page-case__grid">
-        <li
-          v-for="caseItem in data.page.projects"
-          :key="caseItem.slug"
-        >
-          <link-card
-            :internal-link="$localeUrl({ name: 'cases-slug', params: { slug: caseItem.slug} })"
-            :image="caseItem.caseTeaser.image"
-            :title="caseItem.title"
-            :body="caseItem.caseTeaser.title"
-          />
-        </li>
-      </ul>
+      <cases-list :cases="data.page.projects" />
     </section>
 
     <section class="page-cases__cta grid">
@@ -132,17 +120,6 @@
     text-align: center;
   }
 
-  .page-case__grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    row-gap: var(--spacing-medium);
-    column-gap: var(--spacing-medium);
-  }
-
-  .page-case__grid .link-card {
-    height: 100%;
-  }
-
   .page-cases__cta {
     margin-bottom: var(--spacing-medium);
   }
@@ -175,10 +152,6 @@
       max-width: 500px;
     }
 
-    .page-case__grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
     .page-cases__cta {
       margin-bottom: var(--spacing-big);
     }
@@ -200,10 +173,6 @@
     .page-cases__overview-title {
       margin-bottom: var(--spacing-larger);
     }
-
-    .page-case__grid {
-      grid-template-columns: repeat(3, 1fr);
-    }
   }
 
   @media (min-width: 1100px) {
@@ -219,11 +188,6 @@
   @media (min-width: 1200px) {
     .page-cases__overview {
       background-size: 100% 300px;
-    }
-
-    .page-case__grid {
-      row-gap: var(--spacing-large);
-      column-gap: var(--spacing-large);
     }
   }
 </style>

--- a/src/pages/[language]/services/[slug]/index.query.graphql
+++ b/src/pages/[language]/services/[slug]/index.query.graphql
@@ -163,7 +163,7 @@ fragment page on ServiceRecord {
         }
       }
     }
-    ...on SectionCasesListRecord {
+    ...on CasesListRecord {
       id
       cases {
         title

--- a/src/pages/[language]/services/[slug]/index.query.graphql
+++ b/src/pages/[language]/services/[slug]/index.query.graphql
@@ -163,6 +163,22 @@ fragment page on ServiceRecord {
         }
       }
     }
+    ...on SectionCasesListRecord {
+      id
+      cases {
+        title
+        slug
+        caseTeaser {
+          title
+          image {
+            url
+            alt
+            width
+            height
+          }
+        }
+      }
+    }
   }
   breadcrumbsNextService {
     ... on ServiceRecord {

--- a/src/pages/[language]/services/[slug]/index.vue
+++ b/src/pages/[language]/services/[slug]/index.vue
@@ -54,7 +54,7 @@
           :item="item"
         />
         <cases-list
-          v-if="item.__typename === 'SectionCasesListRecord'"
+          v-if="item.__typename === 'CasesListRecord'"
           :key="item.id"
           :id="item.id"
           :cases="item.cases"

--- a/src/pages/[language]/services/[slug]/index.vue
+++ b/src/pages/[language]/services/[slug]/index.vue
@@ -53,6 +53,13 @@
           :id="item.id"
           :item="item"
         />
+        <cases-list
+          v-if="item.__typename === 'SectionCasesListRecord'"
+          :key="item.id"
+          :id="item.id"
+          :cases="item.cases"
+          :max-columns="2"
+        />
       </template>
     </article>
     <pivot-list
@@ -139,7 +146,8 @@
   .page-service__overview > .image-with-caption,
   .page-service__structured-text-section,
   .page-service__overview .blockquote-block,
-  .page-service__overview > .responsive-video {
+  .page-service__overview > .responsive-video,
+  .page-service__overview .cases-list {
     margin: 0 0 var(--spacing-large) 0;
   }
 
@@ -179,7 +187,8 @@
 
     .page-service__overview .blockquote-block,
     .page-service__structured-text-section,
-    .page-service__overview .cta-image-block {
+    .page-service__overview .cta-image-block,
+    .page-service__overview .cases-list {
       width: 70%;
     }
 


### PR DESCRIPTION
## What changes were made
- Create a new component: `cases-list`.
- Replace the old `ul` from the `cases` page with the new component.
- Create a new block in the CMS that allows content editor to render the new component in the `service` pages.
- Make the new component work in the `service` pages.
- Generate migration.

Note: Originally, the `cases-list` component was a section that supported a `title`. But I chose to just render a `ul` because it works great together with the Section Structured Text block. It also allows us to reuse the component in the cases page.

Note 2: Before merging, remove the cases from the random service, it's for preview only.

## How to test or check results

- Visit: https://deploy-preview-739--voorhoede-website.netlify.app/en/services/validate-your-idea/.
- Scroll to the bottom of the page.

## Checks
- [X] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [X] Appointed PR reviewers
