### PR TITLE
Feat: Invert the headers for the services and cases pages.

### DIFF
--- a/src/pages/[language]/cases/index.vue
+++ b/src/pages/[language]/cases/index.vue
@@ -2,7 +2,7 @@
   <main class="page-cases">
     <div class="grid page-cases__top">
       <page-header
-        heading="byline"
+        heading="headline"
         :byline="data.page.title"
         :headline="data.page.subtitle"
       />

--- a/src/pages/[language]/services/index.vue
+++ b/src/pages/[language]/services/index.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="page-services grid">
     <page-header
-      heading="byline"
+      heading="headline"
       :byline="data.page.title"
       :headline="data.page.subtitle"
     />


### PR DESCRIPTION
## What changes were made
The title says it all.

## How to test or check results
Go to `/services` or `/cases`, the longer title should now be the `h1`.

## Checks
- [X] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [X] Appointed PR reviewers
