### PR TITLE
Multilingual blogs

### DIFF
--- a/migrations/1712861380_multilingualBlogs.ts
+++ b/migrations/1712861380_multilingualBlogs.ts
@@ -1,0 +1,68 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Multiple links field "Pinned posts" (`pinned_posts`) in model "Blog post overview" (`blog_post_overview`)'
+  );
+  await client.fields.update("10137946", {
+    localized: false,
+    default_value: null,
+  });
+
+  console.log(
+    'Update Single-line string field "Title" (`title`) in model "Blog post" (`blog_post`)'
+  );
+  await client.fields.update("145703", { localized: false, default_value: "" });
+
+  console.log(
+    'Update SEO meta tags field "Social" (`social`) in model "Blog post" (`blog_post`)'
+  );
+  await client.fields.update("145708", {
+    localized: false,
+    default_value: null,
+  });
+
+  console.log(
+    'Update Slug field "Slug" (`slug`) in model "Blog post" (`blog_post`)'
+  );
+  await client.fields.update("145710", {
+    localized: false,
+    default_value: null,
+  });
+
+  console.log(
+    'Update Modular content field "Items" (`items`) in model "Blog post" (`blog_post`)'
+  );
+  await client.fields.update("166560", {
+    localized: false,
+    default_value: null,
+  });
+
+  console.log(
+    'Update Single-line string field "Intro title" (`intro_title`) in model "Blog post" (`blog_post`)'
+  );
+  await client.fields.update("166561", { localized: false, default_value: "" });
+
+  console.log(
+    'Update Single-line string field "Subtitle" (`subtitle`) in model "Blog post" (`blog_post`)'
+  );
+  await client.fields.update("166562", {
+    localized: false,
+    default_value: "Blog",
+  });
+
+  console.log(
+    'Update Multiple links field "Pivots" (`pivots`) in model "Blog post" (`blog_post`)'
+  );
+  await client.fields.update("1128823", {
+    localized: false,
+    default_value: null,
+  });
+
+  console.log("Finalize models/block models");
+
+  console.log('Update model "Blog post" (`blog_post`)');
+  await client.itemTypes.update("38241", { all_locales_required: true });
+}

--- a/migrations/1712925810_multilingualBlogs.ts
+++ b/migrations/1712925810_multilingualBlogs.ts
@@ -7,62 +7,68 @@ export default async function (client: Client) {
     'Update Multiple links field "Pinned posts" (`pinned_posts`) in model "Blog post overview" (`blog_post_overview`)'
   );
   await client.fields.update("10137946", {
-    localized: false,
-    default_value: null,
+    localized: true,
+    default_value: { en: null, nl: null },
   });
 
   console.log(
     'Update Single-line string field "Title" (`title`) in model "Blog post" (`blog_post`)'
   );
-  await client.fields.update("145703", { localized: false, default_value: "" });
+  await client.fields.update("145703", {
+    localized: true,
+    default_value: { en: "", nl: "" },
+  });
 
   console.log(
     'Update SEO meta tags field "Social" (`social`) in model "Blog post" (`blog_post`)'
   );
   await client.fields.update("145708", {
-    localized: false,
-    default_value: null,
+    localized: true,
+    default_value: { en: null, nl: null },
   });
 
   console.log(
     'Update Slug field "Slug" (`slug`) in model "Blog post" (`blog_post`)'
   );
   await client.fields.update("145710", {
-    localized: false,
-    default_value: null,
+    localized: true,
+    default_value: { en: null, nl: null },
   });
 
   console.log(
     'Update Modular content field "Items" (`items`) in model "Blog post" (`blog_post`)'
   );
   await client.fields.update("166560", {
-    localized: false,
-    default_value: null,
+    localized: true,
+    default_value: { en: null, nl: null },
   });
 
   console.log(
     'Update Single-line string field "Intro title" (`intro_title`) in model "Blog post" (`blog_post`)'
   );
-  await client.fields.update("166561", { localized: false, default_value: "" });
+  await client.fields.update("166561", {
+    localized: true,
+    default_value: { en: "", nl: "" },
+  });
 
   console.log(
     'Update Single-line string field "Subtitle" (`subtitle`) in model "Blog post" (`blog_post`)'
   );
   await client.fields.update("166562", {
-    localized: false,
-    default_value: "Blog",
+    localized: true,
+    default_value: { en: "Blog", nl: "" },
   });
 
   console.log(
     'Update Multiple links field "Pivots" (`pivots`) in model "Blog post" (`blog_post`)'
   );
   await client.fields.update("1128823", {
-    localized: false,
-    default_value: null,
+    localized: true,
+    default_value: { en: null, nl: null },
   });
 
   console.log("Finalize models/block models");
 
   console.log('Update model "Blog post" (`blog_post`)');
-  await client.itemTypes.update("38241", { all_locales_required: true });
+  await client.itemTypes.update("38241", { all_locales_required: false });
 }

--- a/src/components/language-switcher/language-switcher.vue
+++ b/src/components/language-switcher/language-switcher.vue
@@ -34,10 +34,14 @@ const i18nSlugs = await useI18nSlugs();
 const route = useRoute();
 
 const getLocaleRoute = (code) => {
+  const isDynamicRoute = Boolean(i18nSlugs.value)
+  const isTranslationSlugAvailable = Boolean(i18nSlugs.value?.filter((i18nSlug) => i18nSlug.locale === code).length);
+
   const localeSlug = i18nSlugs.value?.find((i18nSlug) => i18nSlug.locale === code);
+  const routeName = (isDynamicRoute && !isTranslationSlugAvailable) ? 'language' : route.name;
 
   return {
-    name: route.name,
+    name: routeName,
     params: {
       ...route.params,
       language: code,

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'implement-google-calendar-schedular-deploy';
+export const datocmsEnvironment = 'multilingual-blogs';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/blog/page/[page].vue
+++ b/src/pages/[language]/blog/page/[page].vue
@@ -28,6 +28,7 @@
       />
 
       <pagination-nav
+        v-if="data.itemsMeta.count > PER_PAGE"
         :total-items="data.itemsMeta.count"
         :current-page="currentPage"
         :per-page="PER_PAGE"

--- a/src/pages/[language]/blog/page/index.query.graphql
+++ b/src/pages/[language]/blog/page/index.query.graphql
@@ -1,4 +1,4 @@
-query Blog($locale: SiteLocale, $skip: IntType, $first: IntType) {
+query Blog($locale: SiteLocale!, $skip: IntType, $first: IntType) {
   page: blogPostOverview(locale: $locale) {
     ...blogPostOverview
   }
@@ -7,13 +7,19 @@ query Blog($locale: SiteLocale, $skip: IntType, $first: IntType) {
     skip: $skip
     locale: $locale
     orderBy: publishDate_DESC
-    filter: { isArchived: { eq: "false" } }
+    filter: {
+      isArchived: { eq: "false" },
+      _locales: { allIn: [$locale] }
+    }
   ) {
     ...blogPost
   }
   itemsMeta: _allBlogPostsMeta(
     locale: $locale
-    filter: { isArchived: { eq: "false" } }
+    filter: {
+      isArchived: { eq: "false" },
+      _locales: { allIn: [$locale] }
+    }
   ) {
     count
   }

--- a/src/pages/[language]/index.query.graphql
+++ b/src/pages/[language]/index.query.graphql
@@ -1,4 +1,4 @@
-query HomePage($locale: SiteLocale, $currentDate: DateTime) {
+query HomePage($locale: SiteLocale!, $currentDate: DateTime) {
   page: home(locale: $locale) {
     ...homepage
   }
@@ -20,7 +20,10 @@ query HomePage($locale: SiteLocale, $currentDate: DateTime) {
     locale: $locale
     first: 3
     orderBy: publishDate_DESC
-    filter: { isArchived: { eq: "false" } }
+    filter: {
+      isArchived: { eq: "false" }
+      _locales: { allIn: [$locale] }
+    }
   ) {
     slug
     title

--- a/src/pages/[language]/team/[slug]/index.blogPosts.graphql
+++ b/src/pages/[language]/team/[slug]/index.blogPosts.graphql
@@ -2,13 +2,18 @@ query TeamSlug($personId: [ItemId]) {
   blogPosts: allBlogPosts(
     first: 100
     filter: { authors: { anyIn: $personId } }
-    orderBy: publishDate_DESC
+    orderBy: publishDate_DESC,
+    fallbackLocales: nl
   ) {
     ...blogPost
   }
 }
 
 fragment blogPost on BlogPostRecord {
+  _allSlugLocales {
+    locale
+    value
+  }
   id
   title
   introTitle

--- a/src/pages/[language]/team/[slug]/index.vue
+++ b/src/pages/[language]/team/[slug]/index.vue
@@ -43,21 +43,33 @@
     </header>
 
     <ul
-      v-if="blogs"
+      v-if="transformedBlogposts"
       class="page-team__blogs"
     >
       <li
-        v-for="blogPost in blogs.blogPosts"
+        v-for="blogPost in transformedBlogposts"
         :key="blogPost.id"
         class="page-team__blog"
       >
-        <app-link :to="$localeUrl({ name: 'blog-slug', params: { slug: blogPost.slug } })">
+        <app-link
+          :to="{ name: 'language-blog-slug', params: {
+            language: blogPost.locale,
+            slug: blogPost.slug
+          }}"
+          :hreflang="blogPost.locale"
+        >
           <div class="page-team__blog-details">
             <span class="body page-team__date">{{ formattedDate(blogPost.date) }}</span>
-            <h2 class="h3 page-team__blog-title">
+            <h2
+              class="h3 page-team__blog-title"
+              :lang="blogPost.locale"
+            >
               {{ blogPost.title }}
             </h2>
-            <p class="body page-team__blog-content">
+            <p
+              class="body page-team__blog-content"
+              :lang="blogPost.locale"
+            >
               {{ blogPost.introTitle }}
             </p>
           </div>
@@ -96,6 +108,14 @@ const { data: blogs } = await useFetchContent({
     personId: person.id,
   },
 })
+
+const transformedBlogposts = computed(() => {
+  return blogs.value.blogPosts.map((blogPost) => ({
+    ...blogPost,
+    locale: blogPost._allSlugLocales.find((locale) => locale.value === blogPost.slug).locale,
+  }))
+})
+
 
 const formattedDate = (date) => formatDate({ date, locale: route.params.language, format: 'D MMM YYYY' })
 

--- a/src/scripts/fetch-blog-feed.ts
+++ b/src/scripts/fetch-blog-feed.ts
@@ -1,5 +1,5 @@
 import type { default as Feed } from '@json-feed-types/1_1';
-import { datocmsFetch } from '../lib/datocms-fetch.ts';
+import { datocmsFetch } from '../lib/datocms-fetch';
 
 type BlogFeedResponse = {
   data: {
@@ -24,7 +24,10 @@ export const fetchBlogFeed = () => {
         allBlogPosts(
           first: 10
           orderBy: publishDate_DESC
-          filter: { isArchived: { eq: "false" } }
+          filter: {
+            isArchived: { eq: "false" },
+            _locales: { allIn: [en] }
+          }
         ) {
           title
           slug

--- a/src/scripts/fetch-i18n-slugs.ts
+++ b/src/scripts/fetch-i18n-slugs.ts
@@ -13,6 +13,10 @@ const operationsWithTranslatedSlugs = [
     route: "language-cases-slug",
     operation: "allCaseItems",
   },
+  {
+    route: "language-blog-slug",
+    operation: "allBlogPosts",
+  },
 ];
 
 // fetches a paginated list of slugs for a given operation


### PR DESCRIPTION
## What changes were made

- Blogs are fully marked as translated in Dato, meaning all translations are not required anymore.
- Both en and nl blog overview only show their respective blogs.
- The language switcher switches to the translated version if available(I think, since there are no blogs in both languages, but it should work)
- People pages link all blogs in both languages, marking them with the lang corerct lang and hreflang attribute.
- The homepage shows the latest blog posts in the current locale
