### PR TITLE
Custom video caption

### DIFF
--- a/migrations/1713346696_addVideoCaption.ts
+++ b/migrations/1713346696_addVideoCaption.ts
@@ -1,0 +1,22 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  const newFields: Record<string, SimpleSchemaTypes.Field> = {};
+
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create Single-line string field "Caption" (`caption`) in block model "Responsive video" (`responsive_video`)'
+  );
+  newFields["BOh-mqy1TM6NJd5-UJp14g"] = await client.fields.create("44361", {
+    label: "Caption",
+    field_type: "string",
+    api_key: "caption",
+    appearance: {
+      addons: [],
+      editor: "single_line",
+      parameters: { heading: false },
+    },
+    default_value: "",
+  });
+}

--- a/src/components/responsive-video/responsive-video.vue
+++ b/src/components/responsive-video/responsive-video.vue
@@ -12,7 +12,7 @@
           target="_blank"
           rel="noopener"
         >
-          {{ props.video.title }}
+          {{ props.caption || props.video.title }}
         </a>
       </div>
     </template>
@@ -45,6 +45,7 @@ interface Props {
   autoplay: boolean;
   loop: boolean;
   mute: boolean;
+  caption?: string;
 }
 
 const props = defineProps<Props>()

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'multilingual-blogs';
+export const datocmsEnvironment = 'video-captions';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -84,6 +84,7 @@ fragment page on BlogPostRecord {
       mute
       loop
       autoplay
+      caption
       video {
         url
         title

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -117,6 +117,7 @@
           :autoplay="item.autoplay"
           :loop="item.loop"
           :mute="item.autoplay"
+          :caption="item.caption"
         />
 
         <div

--- a/src/pages/[language]/cases/[slug]/index.query.graphql
+++ b/src/pages/[language]/cases/[slug]/index.query.graphql
@@ -87,6 +87,7 @@ fragment caseItem on CaseItemRecord {
       mute
       loop
       autoplay
+      caption
       gif {
         url
         title

--- a/src/pages/[language]/cases/[slug]/index.vue
+++ b/src/pages/[language]/cases/[slug]/index.vue
@@ -110,6 +110,7 @@
           :autoplay="item.autoplay"
           :loop="item.loop"
           :mute="item.autoplay"
+          :caption="item.caption"
         />
       </template>
 

--- a/src/pages/[language]/services/[slug]/index.query.graphql
+++ b/src/pages/[language]/services/[slug]/index.query.graphql
@@ -66,6 +66,7 @@ fragment page on ServiceRecord {
       mute
       loop
       autoplay
+      caption
       gif {
         url
         title
@@ -102,7 +103,7 @@ fragment page on ServiceRecord {
         }
       }
     }
-    ...on SectionStructuredTextRecord {
+    ... on SectionStructuredTextRecord {
       gridAlignment
       body {
         value
@@ -163,7 +164,7 @@ fragment page on ServiceRecord {
         }
       }
     }
-    ...on CasesListRecord {
+    ... on CasesListRecord {
       id
       cases {
         title

--- a/src/pages/[language]/services/[slug]/index.vue
+++ b/src/pages/[language]/services/[slug]/index.vue
@@ -46,6 +46,7 @@
           :autoplay="item.autoplay"
           :loop="item.loop"
           :mute="item.autoplay"
+          :caption="item.caption"
         />
         <cta-block
           v-if="item.__typename === 'CallToActionRecord'"


### PR DESCRIPTION
## What changes were made

A new caption field was added to the Responsive Video block model, along with updates to the Vue components and GraphQL queries to support this new field.

## How to test or check results

Test the display of captions in the responsive video components across the website. Ensure the captions are displayed correctly and fall back to video titles when captions are not provided.

On `/en/blog/front-end-at-the-edge/`, the first video should show the caption "This is a custom caption".

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
