### PR TITLE
Use `_firstPublishedAt` for blog posts and remove `publish_date`

### DIFF
--- a/migrations/1713363020_blogPostPublishedDate.ts
+++ b/migrations/1713363020_blogPostPublishedDate.ts
@@ -1,0 +1,35 @@
+import { Client } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client): Promise<void> {
+  const blogPosts = [];
+
+  for await (const record of client.items.listPagedIterator({
+    filter: {
+      type: "blog_post",
+      fields: { publish_date: { exists: true } },
+    },
+  })) {
+    blogPosts.push(record);
+  }
+
+  console.log("Found blog posts:", blogPosts.length);
+  console.log("Attempting to update blog posts");
+
+  // move the 'published' field to the 'meta -> published_at/first_published_at' field
+  const updatedPosts = await Promise.all(
+    blogPosts.map(async (blogPost) => {
+      // update the 'published' field of each blog post
+      return await client.items.update(blogPost.id, {
+        meta: {
+          published_at: new Date(blogPost.publish_date).toISOString(),
+          first_published_at: new Date(blogPost.publish_date).toISOString(),
+        },
+      });
+    })
+  );
+
+  console.log("Updated blog posts:", updatedPosts.length);
+
+  // delete the 'published_date' field
+  await client.fields.destroy("145704");
+}

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'video-captions';
+export const datocmsEnvironment = 'blog-post-published-date';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'multilingual-blogs';
+export const datocmsEnvironment = 'video-captions';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -265,7 +265,7 @@ fragment buttonsList on StructuredTextButtonsListRecord {
 fragment blogpost on BlogPostRecord {
   slug
   title
-  date: publishDate
+  date: _firstPublishedAt
   authors {
     name
     image {

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -22,7 +22,7 @@ fragment page on BlogPostRecord {
     width
     height
   }
-  date: publishDate
+  date: _firstPublishedAt
   authors {
     name
     lastName

--- a/src/pages/[language]/blog/page/index.query.graphql
+++ b/src/pages/[language]/blog/page/index.query.graphql
@@ -6,7 +6,7 @@ query Blog($locale: SiteLocale!, $skip: IntType, $first: IntType) {
     first: $first
     skip: $skip
     locale: $locale
-    orderBy: publishDate_DESC
+    orderBy: _firstPublishedAt_DESC
     filter: {
       isArchived: { eq: "false" },
       _locales: { allIn: [$locale] }
@@ -35,7 +35,7 @@ fragment blogPost on BlogPostRecord {
     }
   }
   title
-  date: publishDate
+  date: _firstPublishedAt
   authors {
     name
     image {

--- a/src/pages/[language]/index.query.graphql
+++ b/src/pages/[language]/index.query.graphql
@@ -2,7 +2,12 @@ query HomePage($locale: SiteLocale!, $currentDate: DateTime) {
   page: home(locale: $locale) {
     ...homepage
   }
-  upcomingEvents: allEventItems(locale: $locale, first: 1, orderBy: date_ASC, filter: {date: {gte: $currentDate}}) {
+  upcomingEvents: allEventItems(
+    locale: $locale
+    first: 1
+    orderBy: date_ASC
+    filter: { date: { gte: $currentDate } }
+  ) {
     date
     social {
       description
@@ -19,15 +24,12 @@ query HomePage($locale: SiteLocale!, $currentDate: DateTime) {
   latestBlogposts: allBlogPosts(
     locale: $locale
     first: 3
-    orderBy: publishDate_DESC
-    filter: {
-      isArchived: { eq: "false" }
-      _locales: { allIn: [$locale] }
-    }
+    orderBy: _firstPublishedAt_DESC
+    filter: { isArchived: { eq: "false" }, _locales: { allIn: [$locale] } }
   ) {
     slug
     title
-    date: publishDate
+    date: _firstPublishedAt
     authors {
       name
       image {

--- a/src/pages/[language]/team/[slug]/index.blogPosts.graphql
+++ b/src/pages/[language]/team/[slug]/index.blogPosts.graphql
@@ -2,7 +2,7 @@ query TeamSlug($personId: [ItemId]) {
   blogPosts: allBlogPosts(
     first: 100
     filter: { authors: { anyIn: $personId } }
-    orderBy: publishDate_DESC,
+    orderBy: _firstPublishedAt_DESC
     fallbackLocales: nl
   ) {
     ...blogPost
@@ -18,7 +18,7 @@ fragment blogPost on BlogPostRecord {
   title
   introTitle
   slug
-  date: publishDate
+  date: _firstPublishedAt
   authors {
     id
     name

--- a/src/scripts/fetch-blog-feed.ts
+++ b/src/scripts/fetch-blog-feed.ts
@@ -23,7 +23,7 @@ export const fetchBlogFeed = () => {
       query BlogFeed {
         allBlogPosts(
           first: 10
-          orderBy: publishDate_DESC
+          orderBy: _firstPublishedAt_DESC
           filter: {
             isArchived: { eq: "false" },
             _locales: { allIn: [en] }
@@ -31,7 +31,7 @@ export const fetchBlogFeed = () => {
         ) {
           title
           slug
-          publishDate
+          publishDate: _firstPublishedAt
           introTitle
           social {
             description


### PR DESCRIPTION
## What changes were made

- **migrations/1713363020_blogPostPublishedDate.ts**
  - Added a migration script to transfer the 'published' field data to 'meta -> published_at' and 'meta -> first_published_at' for blog posts. The 'publish_date' field is also deleted after updating.
- **src/pages/[language]/blog/[slug]/index.query.graphql**
  - Modified the GraphQL query to retrieve the first published date of blog posts using the `_firstPublishedAt` field instead of `publishDate`.
- **src/pages/[language]/blog/page/index.query.graphql**
  - Updated the GraphQL query for blog listing, changing the sorting order to use `_firstPublishedAt_DESC` instead of `publishDate_DESC` and updating the date field in the blog post fragment to `_firstPublishedAt`.

## How to test or check results

Check the oldest blog posts and see if the dates are correct

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers

## Before merging 🚧

- First merge this PR
- After the PR is merged, run the migration on the primary environment