### PR TITLE
Blog post filtering by using tags

### DIFF
--- a/migrations/1715000075_tags.ts
+++ b/migrations/1715000075_tags.ts
@@ -1,0 +1,118 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  const newFields: Record<string, SimpleSchemaTypes.Field> = {};
+  const newItemTypes: Record<string, SimpleSchemaTypes.ItemType> = {};
+  const newMenuItems: Record<string, SimpleSchemaTypes.MenuItem> = {};
+
+  console.log('Rename model "Tag" (`tag`)');
+
+  console.log('Update block model "Counter Item List" (`counter_item_list`)');
+  await client.itemTypes.update("1775016", {
+    name: "Counter Item List",
+    api_key: "structured_text_counter_item_list",
+  });
+
+  console.log('Update block model "Counter Item" (`counter_item`)');
+  await client.itemTypes.update("1994024", {
+    name: "Counter Item",
+    api_key: "counter_item",
+  });
+
+  console.log("Create new models/block models");
+
+  console.log('Create model "Tag" (`tag`)');
+  newItemTypes["L6X45m4qSbe9KUR9J42WoQ"] = await client.itemTypes.create(
+    {
+      name: "Tag",
+      api_key: "tag",
+      collection_appearance: "table",
+      inverse_relationships_enabled: false,
+      all_locales_required: true,
+    },
+    { skip_menu_item_creation: true }
+  );
+
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create Single-line string field "Title" (`title`) in model "Tag" (`tag`)'
+  );
+  newFields["YQlq6npeQ-ye9GRd6kzlZA"] = await client.fields.create(
+    newItemTypes["L6X45m4qSbe9KUR9J42WoQ"],
+    {
+      label: "Title",
+      field_type: "string",
+      api_key: "title",
+      localized: true,
+      appearance: {
+        addons: [],
+        editor: "single_line",
+        parameters: { heading: false },
+      },
+      default_value: { en: "", nl: "" },
+    }
+  );
+
+  console.log('Create Slug field "Slug" (`slug`) in model "Tag" (`tag`)');
+  newFields["Pdx_CmhQScSROi_y-nV9CQ"] = await client.fields.create(
+    newItemTypes["L6X45m4qSbe9KUR9J42WoQ"],
+    {
+      label: "Slug",
+      field_type: "slug",
+      api_key: "slug",
+      localized: true,
+      validators: {
+        slug_title_field: {
+          title_field_id: newFields["YQlq6npeQ-ye9GRd6kzlZA"].id,
+        },
+        slug_format: { predefined_pattern: "webpage_slug" },
+        required: {},
+        unique: {},
+      },
+      appearance: {
+        addons: [],
+        editor: "slug",
+        parameters: { url_prefix: null },
+      },
+    }
+  );
+
+  console.log(
+    'Create Multiple links field "Tags" (`tags`) in model "Blog post" (`blog_post`)'
+  );
+  newFields["WK7wupK2Tme8U1B-LlMz0g"] = await client.fields.create("38241", {
+    label: "Tags",
+    field_type: "links",
+    api_key: "tags",
+    validators: {
+      items_item_type: {
+        on_publish_with_unpublished_references_strategy: "fail",
+        on_reference_unpublish_strategy: "delete_references",
+        on_reference_delete_strategy: "delete_references",
+        item_types: [newItemTypes["L6X45m4qSbe9KUR9J42WoQ"].id],
+      },
+    },
+    appearance: { addons: [], editor: "links_select", parameters: {} },
+    default_value: null,
+  });
+
+  console.log("Finalize models/block models");
+
+  await client.itemTypes.update(newItemTypes["L6X45m4qSbe9KUR9J42WoQ"], {
+    title_field: newFields["YQlq6npeQ-ye9GRd6kzlZA"],
+  });
+
+  console.log("Manage menu items");
+
+  console.log('Create menu item "Tags"');
+  newMenuItems["FwJmlOZ0QrSGeMIlGUanqg"] = await client.menuItems.create({
+    label: "Tags",
+    item_type: newItemTypes["L6X45m4qSbe9KUR9J42WoQ"],
+  });
+
+  console.log('Update menu item "Tags"');
+  await client.menuItems.update(newMenuItems["FwJmlOZ0QrSGeMIlGUanqg"], {
+    position: 10,
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "vue-datocms": "^4.0.6"
       },
       "devDependencies": {
-        "@datocms/cli": "^1.1.10",
+        "@datocms/cli": "^2.0.4",
         "@typescript-eslint/parser": "^6.4.1",
         "datocms-html-to-structured-text": "^2.1.11",
         "eslint": "^8.48.0",
@@ -607,12 +607,12 @@
       }
     },
     "node_modules/@datocms/cli": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@datocms/cli/-/cli-1.1.10.tgz",
-      "integrity": "sha512-N5bj9n/JKGoakqrBdwCeIBDcQjwkYXkDK9RfMhayAwclWhpGHp9W+dz15A+SbzYi3dfOX2vLccbRfwG6079M1g==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@datocms/cli/-/cli-2.0.4.tgz",
+      "integrity": "sha512-6Hlp8w6nv232MKUj2Zv0GVOjCIGSbrwIX2dKHWdGhIsfQq6dPkS6eIXVVwFtp0CrgT3pH/AgEFinCL3tkhZUPQ==",
       "dev": true,
       "dependencies": {
-        "@datocms/cli-utils": "^1.1.7",
+        "@datocms/cli-utils": "^2.0.2",
         "@datocms/rest-client-utils": "^1",
         "@oclif/plugin-autocomplete": "^1.2.0",
         "@oclif/plugin-help": "^5",
@@ -633,48 +633,84 @@
       }
     },
     "node_modules/@datocms/cli-utils": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@datocms/cli-utils/-/cli-utils-1.1.7.tgz",
-      "integrity": "sha512-BSeET9Nv66hbL05DoClltnwuZ1gC3g4QxatQCgqDcVfnc3wZA5APo9BnUwlPS2PNvFeY6B0yo5BJx3B5/JhFuw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@datocms/cli-utils/-/cli-utils-2.0.2.tgz",
+      "integrity": "sha512-wzzFxFd7QYLSIBiqW5FZg8BbD/U/7COJPkFqWVGfj/T0ecc8UkE0KizFzV2x9gAJlFXFdRC62plm6V3CJNc5cg==",
       "dev": true,
       "dependencies": {
-        "@datocms/cma-client-node": "^1",
+        "@datocms/cma-client-node": ">=3.1.3",
         "@oclif/core": "^1",
+        "@whatwg-node/fetch": "^0.9.14",
         "chalk": "^4",
         "dotenv": "^16.0.1",
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@datocms/cma-client": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@datocms/cma-client/-/cma-client-1.3.2.tgz",
-      "integrity": "sha512-KFqPz/LxNVB9aN7DDQqPMlRHpCmgwhwclvmsiqFPlE5bHfl1eq3lHHSkMU4kIsD7KrNV+KnbuKVUtqmw1IEFqw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@datocms/cma-client/-/cma-client-3.3.1.tgz",
+      "integrity": "sha512-MRfG0aFXiDTV6z31Bl61yDSHj2mmdzCvUa5XI7+IeD+dh3qnnunZhitQuCZ4YrR2TDHs0D/qv2bGNpRPoNCZDQ==",
       "dev": true,
       "dependencies": {
-        "@datocms/rest-client-utils": "^1.3.2"
+        "@datocms/rest-client-utils": "^3.3.1",
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/@datocms/cma-client-node": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@datocms/cma-client-node/-/cma-client-node-1.3.2.tgz",
-      "integrity": "sha512-q60HfH1WhmuW37ff3YpJuuM2vMHXwUQbAbrhLpC5xy0YUwt5VFELZ/mM/6ctKZ2owxiOY4Ughx/TOZ5Wbd18+Q==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@datocms/cma-client-node/-/cma-client-node-3.3.1.tgz",
+      "integrity": "sha512-CT/3BI0o6p/0jKl0FKQ9YvryPdEROMUxiUu+fBTgGNTdf4ew/z3WOurHX5/Jm87ibagrK8w+41hBp9S6IxwTdg==",
       "dev": true,
       "dependencies": {
-        "@datocms/cma-client": "^1.3.2",
-        "@datocms/rest-client-utils": "^1.3.2",
+        "@datocms/cma-client": "^3.3.1",
+        "@datocms/rest-client-utils": "^3.3.1",
         "got": "^11.8.5",
         "mime-types": "^2.1.35",
         "tmp-promise": "^3.0.3"
       }
     },
+    "node_modules/@datocms/cma-client-node/node_modules/@datocms/rest-client-utils": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@datocms/rest-client-utils/-/rest-client-utils-3.3.1.tgz",
+      "integrity": "sha512-3TGEyRak+F8zFo/4ILJzBnPlntEN7q0uZor1dholXmAVRSGGEOB4WYCBJj837b4vk+edtS2qBgpCEDhKygkMbQ==",
+      "dev": true,
+      "dependencies": {
+        "async-scheduler": "^1.4.4"
+      }
+    },
+    "node_modules/@datocms/cma-client/node_modules/@datocms/rest-client-utils": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@datocms/rest-client-utils/-/rest-client-utils-3.3.1.tgz",
+      "integrity": "sha512-3TGEyRak+F8zFo/4ILJzBnPlntEN7q0uZor1dholXmAVRSGGEOB4WYCBJj837b4vk+edtS2qBgpCEDhKygkMbQ==",
+      "dev": true,
+      "dependencies": {
+        "async-scheduler": "^1.4.4"
+      }
+    },
     "node_modules/@datocms/rest-client-utils": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@datocms/rest-client-utils/-/rest-client-utils-1.3.2.tgz",
-      "integrity": "sha512-byPjYvFa+CshiZhPbgfymvtO2dJUHuoKEg44S5e54gbTHepuGtbybDrxpuBtiPhwWRcolHUxKrMttNMDQbMyDA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@datocms/rest-client-utils/-/rest-client-utils-1.3.3.tgz",
+      "integrity": "sha512-hAfzEKs2vHUIg+kZNheMaSy5Azl82kIKJeY+dzydyacwcXdbF4BcHSKR7My7lSZm3sy7RTpqsp/azT5vY64vtQ==",
       "dev": true,
       "dependencies": {
         "@whatwg-node/fetch": "^0.5.3",
         "async-scheduler": "^1.4.4"
+      }
+    },
+    "node_modules/@datocms/rest-client-utils/node_modules/@whatwg-node/fetch": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.5.4.tgz",
+      "integrity": "sha512-dR5PCzvOeS7OaW6dpIlPt+Ou3pak7IEG+ZVAV26ltcaiDB3+IpuvjqRdhsY6FKHcqBo1qD+S99WXY9Z6+9Rwnw==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "abort-controller": "^3.0.0",
+        "busboy": "^1.6.0",
+        "form-data-encoder": "^1.7.1",
+        "formdata-node": "^4.3.1",
+        "node-fetch": "^2.6.7",
+        "undici": "^5.12.0",
+        "web-streams-polyfill": "^3.2.0"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -1184,6 +1220,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@json-feed-types/common/-/common-1.0.2.tgz",
       "integrity": "sha512-IWcSEjI+2bjl1T0R4cIPHu2DZ6PF/unRdEl9VZ1vTtLNaybzirGCywat+KLIpbmxrg48kRNgasH4CBYkq99NDw=="
+    },
+    "node_modules/@kamilkisiela/fast-url-parser": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz",
+      "integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
+      "dev": true
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.10",
@@ -1994,24 +2036,24 @@
       }
     },
     "node_modules/@oclif/screen": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
-      "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==",
-      "deprecated": "Deprecated in favor of @oclif/core",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.8.tgz",
+      "integrity": "sha512-yx6KAqlt3TAHBduS2fMQtJDL2ufIHnDRArrJEOoTTuizxqmjLT+psGYOHpmMl3gvQpFJ11Hs76guUUktzAF9Bg==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
-      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+      "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
       "dev": true,
       "dependencies": {
         "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@peculiar/json-schema": {
@@ -2027,16 +2069,16 @@
       }
     },
     "node_modules/@peculiar/webcrypto": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
-      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.6.tgz",
+      "integrity": "sha512-YBcMfqNSwn3SujUJvAaySy5tlYbYm6tVt9SKoXu8BaTdKGROiJDgPR3TXpZdAKUfklzm3lRapJEAltiMQtBgZg==",
       "dev": true,
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.8",
         "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.5.0",
-        "webcrypto-core": "^1.7.7"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.7.9"
       },
       "engines": {
         "node": ">=10.12.0"
@@ -2367,9 +2409,9 @@
       }
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
     },
     "node_modules/@types/http-proxy": {
@@ -2406,9 +2448,9 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
     },
     "node_modules/@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2886,20 +2928,42 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
     },
+    "node_modules/@whatwg-node/events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.5.4.tgz",
-      "integrity": "sha512-dR5PCzvOeS7OaW6dpIlPt+Ou3pak7IEG+ZVAV26ltcaiDB3+IpuvjqRdhsY6FKHcqBo1qD+S99WXY9Z6+9Rwnw==",
+      "version": "0.9.17",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.17.tgz",
+      "integrity": "sha512-TDYP3CpCrxwxpiNY0UMNf096H5Ihf67BK1iKGegQl5u9SlpEDYrvnV71gWBGJm+Xm31qOy8ATgma9rm8Pe7/5Q==",
       "dev": true,
       "dependencies": {
-        "@peculiar/webcrypto": "^1.4.0",
-        "abort-controller": "^3.0.0",
+        "@whatwg-node/node-fetch": "^0.5.7",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+      "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
+      "dev": true,
+      "dependencies": {
+        "@kamilkisiela/fast-url-parser": "^1.1.4",
+        "@whatwg-node/events": "^0.1.0",
         "busboy": "^1.6.0",
-        "form-data-encoder": "^1.7.1",
-        "formdata-node": "^4.3.1",
-        "node-fetch": "^2.6.7",
-        "undici": "^5.12.0",
-        "web-streams-polyfill": "^3.2.0"
+        "fast-querystring": "^1.1.1",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/abbrev": {
@@ -3462,9 +3526,9 @@
       }
     },
     "node_modules/cacheable-request": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
-      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dev": true,
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -4833,6 +4897,12 @@
         "ufo": "^1.1.2"
       }
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4867,6 +4937,15 @@
       "dev": true,
       "dependencies": {
         "fastest-levenshtein": "^1.0.7"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dev": true,
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
       }
     },
     "node_modules/fastest-levenshtein": {
@@ -6280,9 +6359,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -8437,12 +8516,12 @@
       }
     },
     "node_modules/pvtsutils": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
-      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.6.1"
       }
     },
     "node_modules/pvutils": {
@@ -9367,15 +9446,12 @@
       }
     },
     "node_modules/tmp-promise/node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-fast-properties": {
@@ -9466,9 +9542,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -9860,10 +9936,29 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -10269,16 +10364,16 @@
       }
     },
     "node_modules/webcrypto-core": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
-      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.9.tgz",
+      "integrity": "sha512-FE+a4PPkOmBbgNDIyRmcHhgXn+2ClRl3JzJdDu/P4+B8y81LqKe6RAsI9b3lAOHe1T1BMkSjsRHTYRikImZnVA==",
       "dev": true,
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.8",
         "@peculiar/json-schema": "^1.1.12",
         "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.2",
-        "tslib": "^2.4.0"
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "vue-datocms": "^4.0.6"
   },
   "devDependencies": {
-    "@datocms/cli": "^1.1.10",
+    "@datocms/cli": "^2.0.4",
     "@typescript-eslint/parser": "^6.4.1",
     "datocms-html-to-structured-text": "^2.1.11",
     "eslint": "^8.48.0",

--- a/src/components/counter-item-list/counter-item-list.vue
+++ b/src/components/counter-item-list/counter-item-list.vue
@@ -1,0 +1,40 @@
+<template>
+  <ul class="counter-item-list">
+    <li
+      v-for="item in items"
+      :key="item.id"
+      class="counter-item-list__item body-big"
+    >
+      <strong>{{ item.amount }}</strong> {{ item.label }}
+    </li>
+  </ul>
+</template>
+
+<script lang="ts" setup>
+  type Props = {
+    items: {
+      id: string
+      amount: number
+      label: string
+    }[]
+  }
+
+  defineProps<Props>()
+</script>
+
+<style>
+  .counter-item-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--spacing-smaller);
+  }
+
+  .counter-item-list__item {
+    padding: .2rem 1rem .1rem;
+    color: var(--html-blue);
+    background: var(--brand-yellow);
+    border-radius: 2rem;
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/counter-item-list/counter-item-list.vue
+++ b/src/components/counter-item-list/counter-item-list.vue
@@ -11,15 +11,13 @@
 </template>
 
 <script lang="ts" setup>
-  type Props = {
-    items: {
+  defineProps<{
+    items: Array<{
       id: string
       amount: number
       label: string
-    }[]
-  }
-
-  defineProps<Props>()
+    }>
+  }>()
 </script>
 
 <style>

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -26,7 +26,7 @@
   import { isHeading, isParagraph, isList  } from 'datocms-structured-text-utils'
   import slugify from '../../lib/slugify';
   import AppButton from '../app-button/app-button.vue'
-  import TagList from '../tag-list/tag-list.vue'
+  import CounterItemList from '../counter-item-list/counter-item-list.vue'
   import ImageWithCaption from '../image-with-caption/image-with-caption.vue'
   import StructuredTextBlock from './structured-text-block.vue'
   import TwoColumnBlock from '../two-column-block/two-column-block.vue';
@@ -139,8 +139,8 @@
           })
         }))
       }
-      case 'StructuredTextTagListRecord': {
-        return h(TagList, {
+      case 'StructuredTextCounterItemListRecord': {
+        return h(CounterItemList, {
           key: record.id,
           items: record.items
         })

--- a/src/components/tag-list/tag-list.vue
+++ b/src/components/tag-list/tag-list.vue
@@ -3,19 +3,30 @@
     <li
       v-for="item in items"
       :key="item.id"
-      class="tag-list__item body-big"
     >
-      <strong>{{ item.amount }}</strong> {{ item.label }}
+      <nuxt-link
+        class="tag-list__item"
+        :to="item.to"
+        :class="{
+          'tag-list__item--active': item.isActive
+        }"
+      >
+        {{ item.title }}
+      </nuxt-link>
     </li>
   </ul>
 </template>
 
 <script lang="ts" setup>
+import { NuxtLinkProps } from 'nuxt/app'
+
   type Props = {
     items: {
       id: string
-      amount: number
-      label: string
+      title: number
+      slug: string
+      to: NuxtLinkProps['to']
+      isActive: boolean
     }[]
   }
 
@@ -26,15 +37,20 @@
   .tag-list {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
     gap: var(--spacing-smaller);
   }
 
   .tag-list__item {
-    padding: .2rem 1rem .1rem;
+    font-family: var(--font-sans);
+    padding: 0.5rem 1.5rem;
     color: var(--html-blue);
     background: var(--brand-yellow);
     border-radius: 2rem;
     white-space: nowrap;
+    border: 1px solid var(--brand-yellow);
+  }
+
+  .tag-list__item--active {
+    border: 1px solid var(--html-blue);
   }
 </style>

--- a/src/components/tag-list/tag-list.vue
+++ b/src/components/tag-list/tag-list.vue
@@ -20,17 +20,15 @@
 <script lang="ts" setup>
 import { NuxtLinkProps } from 'nuxt/app'
 
-  type Props = {
-    items: {
+  defineProps<{
+    items: Array<{
       id: string
       title: number
       slug: string
       to: NuxtLinkProps['to']
       isActive: boolean
-    }[]
-  }
-
-  defineProps<Props>()
+    }>
+  }>()
 </script>
 
 <style>

--- a/src/components/tag-list/tag-list.vue
+++ b/src/components/tag-list/tag-list.vue
@@ -41,13 +41,14 @@ import { NuxtLinkProps } from 'nuxt/app'
   }
 
   .tag-list__item {
+    display: inline-block;
     font-family: var(--font-sans);
     padding: 0.5rem 1.5rem;
     color: var(--html-blue);
-    background: var(--brand-yellow);
+    background: var(--bg-pastel);
     border-radius: 2rem;
     white-space: nowrap;
-    border: 1px solid var(--brand-yellow);
+    border: 1px solid transparent;
   }
 
   .tag-list__item--active {

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'tags';
+export const datocmsEnvironment = 'tags-fresh';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'blog-post-published-date';
+export const datocmsEnvironment = 'tags';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -95,7 +95,7 @@ query Page($locale: SiteLocale, $slug: String) {
           ...link
         }
       }
-      ...on SectionStructuredTextRecord {
+      ... on SectionStructuredTextRecord {
         gridAlignment
         hasToc
         backgroundColor
@@ -128,7 +128,7 @@ query Page($locale: SiteLocale, $slug: String) {
                 }
               }
             }
-            ... on StructuredTextTagListRecord {
+            ... on StructuredTextCounterItemListRecord {
               id
               items {
                 id

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -130,6 +130,11 @@ fragment page on BlogPostRecord {
       }
     }
   }
+  tags {
+    id
+    title
+    slug
+  }
 }
 
 fragment link on RecordInterface {

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -180,6 +180,17 @@
         <scroll-to direction="up" />
       </div>
     </section>
+
+    <section
+      v-if="tags?.length"
+      class="page-blog-post__tags"
+    >
+      <h2 class="h4 page-blog-post__tags-title">
+        {{ $t('read_more_on') }}
+      </h2>
+
+      <tag-list :items="tags" />
+    </section>
   </main>
 </template>
 
@@ -191,6 +202,8 @@
   import prismjs from 'prismjs';
   import('prismjs/components/prism-graphql');
   import('prismjs/components/prism-rust');
+
+  const { $localeUrl } = useNuxtApp();
 
   const defaultHeadingLevel = 3;
 
@@ -235,6 +248,15 @@
   const tocItems = computed(() => {
     return items.value.filter(item => item.titleId)
   })
+
+  const tags = computed(() => {
+    return data.value.page.tags.map(tag => {
+      return {
+        ...tag,
+        to: $localeUrl({ name: 'blog-tag-slug', params: { slug: tag.slug } }),
+      }
+    })
+  });
 </script>
 
 <style>
@@ -262,8 +284,17 @@
     grid-row: 2;
   }
 
-  .page-blog-post__link-container {
+  .page-blog-post__tags {
     grid-row: 4;
+    padding-bottom: var(--spacing-large);
+  }
+
+  .page-blog-post__tags-title {
+    margin-bottom: var(--spacing-medium);
+  }
+
+  .page-blog-post__link-container {
+    grid-row: 5;
     padding-top: var(--spacing-small);
     border-top: 2px solid var(--very-dim);
     margin-bottom: var(--spacing-bigger);
@@ -272,7 +303,7 @@
   .page-blog-post__pivots {
     position: relative;
     grid-column: var(--grid-page);
-    grid-row: 5;
+    grid-row: 6;
     background-color: var(--bg-pastel);
   }
 
@@ -311,7 +342,8 @@
   }
 
   @media (min-width: 720px) {
-    .page-blog-post-list > * {
+    .page-blog-post-list > *,
+    .page-blog-post__tags {
       margin-bottom: var(--spacing-larger);
       padding: 0 var(--spacing-larger);
     }
@@ -327,6 +359,10 @@
 
     .page-blog-post-list {
       grid-row: 2;
+    }
+
+    .page-blog-post-list,
+    .page-blog-post__tags {
       grid-column-start: 10;
       grid-column-end: 50;
     }
@@ -351,11 +387,13 @@
   }
 
   @media (min-width: 1100px) {
-    .page-blog-post-list > * {
+    .page-blog-post-list > *,
+    .page-blog-post__tags {
       padding: 0 var(--spacing-big);
     }
 
-    .page-blog-post-list {
+    .page-blog-post-list,
+    .page-blog-post__tags {
       grid-column-start: 12;
       grid-column-end: 46;
     }
@@ -367,13 +405,19 @@
   }
 
   @media (min-width: 1440px) {
-    .page-blog-post-list > * {
+    .page-blog-post-list > *,
+    .page-blog-post__tags {
       padding: 0 var(--spacing-bigger);
     }
 
-    .page-blog-post-list {
+    .page-blog-post-list,
+    .page-blog-post__tags {
       grid-column-start: 12;
       grid-column-end: 44;
+    }
+
+    .page-blog-post__tags {
+      margin-bottom: var(--spacing-large);
     }
   }
 </style>

--- a/src/pages/[language]/blog/page/[page].vue
+++ b/src/pages/[language]/blog/page/[page].vue
@@ -22,7 +22,10 @@
           </p>
         </text-block>
 
-        <nav class="page-blog__tags">
+        <nav
+          v-if="tags.length"
+          class="page-blog__tags"
+        >
           <tag-list :items="tags" />
         </nav>
 
@@ -127,6 +130,10 @@
   });
 
   const tags = computed(() => {
+    if (!pageData.value?.tags.length) {
+      return []
+    }
+
     const hash = `#${SECTION_ID}`
 
     return [

--- a/src/pages/[language]/blog/page/[page].vue
+++ b/src/pages/[language]/blog/page/[page].vue
@@ -1,59 +1,69 @@
 <template>
-  <main class="page-blog">
-    <page-header
-      heading="byline"
-      :byline="data.page.title"
-      :headline="data.page.subtitle"
-      :image="data.page.headerIllustration"
-    />
-
-    <section
-      :id="SECTION_ID"
-      class="page-blog-container grid"
-    >
-      <h2 class="sr-only">
-        {{ $t('blog_overview') }}
-      </h2>
-
-      <text-block class="page-blog__text">
-        <p class="testimonial">
-          {{ data.page.description }}
-        </p>
-      </text-block>
-
-      <blogs-list
-        :items="data.items"
-        :pinned-items="currentPage === 1 ? data.page.pinnedPosts : []"
-        class="page-blog__posts"
+  <div key="page-blog">
+    <main class="page-blog">
+      <page-header
+        heading="byline"
+        :byline="pageData.page.title"
+        :headline="pageData?.tag?.name || pageData.page.subtitle"
+        :image="pageData.page.headerIllustration"
       />
 
-      <pagination-nav
-        v-if="data.itemsMeta.count > PER_PAGE"
-        :total-items="data.itemsMeta.count"
-        :current-page="currentPage"
-        :per-page="PER_PAGE"
-        :get-paginated-route="getPaginatedRoute"
-        class="page-blog__pagination"
-      />
-    </section>
+      <section
+        :id="SECTION_ID"
+        class="page-blog-container grid"
+      >
+        <h2 class="sr-only">
+          {{ $t('blog_overview') }}
+        </h2>
 
-    <section class="page-blog__pivots grid">
-      <pivot-list
-        v-if="data.page.pivots && data.page.pivots.length"
-        :pivots="data.page.pivots"
-        :can-have-border-top="false"
-        :pivot-narrow="true"
-      />
+        <text-block class="page-blog__text">
+          <p class="testimonial">
+            {{ pageData.page.description }}
+          </p>
+        </text-block>
 
-      <div class="page-blog__scroll-to">
-        <scroll-to direction="up" />
-      </div>
-    </section>
-  </main>
+        <nav class="page-blog__tags">
+          <tag-list :items="tags" />
+        </nav>
+
+        <blogs-list
+          :items="pageData.items"
+          :pinned-items="shouldShowPinnedPosts ? pageData.page.pinnedPosts : []"
+          class="page-blog__posts"
+        />
+
+        <pagination-nav
+          v-if="pageData.itemsMeta.count > PER_PAGE"
+          :total-items="pageData.itemsMeta.count"
+          :current-page="currentPage"
+          :per-page="PER_PAGE"
+          :get-paginated-route="getPaginatedRoute"
+          class="page-blog__pagination"
+        />
+      </section>
+
+      <section class="page-blog__pivots grid">
+        <pivot-list
+          v-if="pageData.page.pivots && pageData.page.pivots.length"
+          :pivots="pageData.page.pivots"
+          :can-have-border-top="false"
+          :pivot-narrow="true"
+        />
+
+        <div class="page-blog__scroll-to">
+          <scroll-to direction="up" />
+        </div>
+      </section>
+    </main>
+  </div>
 </template>
 
 <script setup>
-  import query from './index.query.graphql?raw';
+  import tagIdQuery from './tagId.query.graphql?raw';
+  import pageQuery from './index.query.graphql?raw';
+
+  const app = useNuxtApp();
+  const route = useRoute();
 
   const { $localeUrl } = useNuxtApp();
 
@@ -86,27 +96,74 @@
     return (currentPage.value - 1) * PER_PAGE;
   });
 
-  const { data } = await useFetchContent({
-    query,
+  let tagId = undefined
+
+  if (params.slug) {
+    const { data: tagData } = await useFetchContent({
+      key: [route.name, params.slug, params.page].join('-'),
+      query: tagIdQuery,
+      variables: {
+        tagSlug: params.slug,
+        locale: params.language,
+      }
+    });
+
+    tagId = tagData.value?.tag?.id;
+  }
+
+  const tagFilter = tagId ? {
+    anyIn: [tagId]
+  } : null
+
+  const { data: pageData } = await useFetchContent({
+    query: pageQuery,
     variables: {
       locale: params.language,
       skip: skip.value,
       first: PER_PAGE,
+      tagId,
+      tagFilter
     },
   });
 
-  // If the page is out of range, redirect to the first page
-  if (data.value.items.length === 0) {
-    await navigateTo({ params: { page: 1 }})
-  }
+  const tags = computed(() => {
+    const hash = `#${SECTION_ID}`
 
-  useSeoHead(data.value.page);
+    return [
+      {
+        id: null,
+        title: app.$t('all_blogposts'),
+        to: $localeUrl({ name: 'blog', hash }),
+        isActive: !params.slug
+      },
+      ...(pageData.value?.tags.map(tag => {
+        return {
+          ...tag,
+          to: $localeUrl({ name: 'blog-tag-slug', params: { slug: tag.slug }, hash }),
+          isActive: tag.slug === params.slug
+        }
+      }) || {})
+    ]
+  });
+
+  // Only show pinned posts on the first page and if no tag is selected
+  const shouldShowPinnedPosts = currentPage.value === 1 && !tagId;
+
+  useSeoHead(pageData.value.page);
 
   function getPaginatedRoute(pageNumber) {
     if (pageNumber === 1) {
-      return $localeUrl({ name: 'blog', hash: `#${SECTION_ID}` });
+      if (params.slug) {
+        return $localeUrl({ name: 'blog-tag-slug', params: { slug: params.slug }, hash: `#${SECTION_ID}` });
+      } else {
+        return $localeUrl({ name: 'blog', hash: `#${SECTION_ID}` });
+      }
     } else {
-      return $localeUrl({ name: 'blog-page-page', params: { page: pageNumber }, hash: `#${SECTION_ID}` });
+      if (params.slug) {
+        return $localeUrl({ name: 'blog-tag-slug-page-page', params: { slug: params.slug, page: pageNumber }, hash: `#${SECTION_ID}` });
+      } else {
+        return $localeUrl({ name: 'blog-page-page', params: { page: pageNumber }, hash: `#${SECTION_ID}` });
+      }
     }
   }
 </script>
@@ -116,20 +173,32 @@
     padding-top: var(--spacing-larger);
   }
 
+  .page-blog__text,
+  .page-blog__tags {
+    margin-bottom: var(--spacing-large);
+    padding-bottom: var(--spacing-medium);
+  }
+
   .page-blog__text {
-    margin-bottom: var(--spacing-larger);
     grid-row: 1;
     color: var(--html-blue);
   }
 
-  .page-blog__posts {
+  .page-blog__tags {
     grid-row: 2;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-small);
+  }
+
+  .page-blog__posts {
+    grid-row: 3;
     margin-bottom: var(--spacing-large);
     grid-column: var(--grid-content);
   }
 
   .page-blog__pagination {
-    grid-row: 3;
+    grid-row: 4;
     margin: auto;
   }
 
@@ -150,10 +219,12 @@
   @media (min-width: 720px) {
     .page-blog__text,
     .page-blog__posts,
+    .page-blog__tags,
     .page-blog__pagination {
       grid-column-start: 5;
       grid-column-end: 47;
       margin-bottom: var(--spacing-large);
+      padding-bottom: var(--spacing-medium);
     }
 
     .page-blog-container {
@@ -168,6 +239,7 @@
   @media (min-width: 1100px) {
     .page-blog__text,
     .page-blog__posts,
+    .page-blog__tags,
     .page-blog__pagination {
       grid-column-start: 14;
       grid-column-end: 42;

--- a/src/pages/[language]/blog/page/index.query.graphql
+++ b/src/pages/[language]/blog/page/index.query.graphql
@@ -1,4 +1,10 @@
-query Blog($locale: SiteLocale!, $skip: IntType, $first: IntType) {
+query Blog(
+  $locale: SiteLocale!
+  $skip: IntType
+  $first: IntType
+  $tagFilter: LinksFilter
+  $tagId: ItemId
+) {
   page: blogPostOverview(locale: $locale) {
     ...blogPostOverview
   }
@@ -8,7 +14,8 @@ query Blog($locale: SiteLocale!, $skip: IntType, $first: IntType) {
     locale: $locale
     orderBy: _firstPublishedAt_DESC
     filter: {
-      isArchived: { eq: "false" },
+      isArchived: { eq: "false" }
+      tags: $tagFilter
       _locales: { allIn: [$locale] }
     }
   ) {
@@ -17,11 +24,22 @@ query Blog($locale: SiteLocale!, $skip: IntType, $first: IntType) {
   itemsMeta: _allBlogPostsMeta(
     locale: $locale
     filter: {
-      isArchived: { eq: "false" },
+      isArchived: { eq: "false" }
+      tags: $tagFilter
       _locales: { allIn: [$locale] }
     }
   ) {
     count
+  }
+  tags: allTags(locale: $locale) {
+    id
+    title
+    slug
+  }
+  tag: tag(filter: { id: { eq: $tagId } }) {
+    id
+    title
+    slug
   }
 }
 

--- a/src/pages/[language]/blog/page/tagId.query.graphql
+++ b/src/pages/[language]/blog/page/tagId.query.graphql
@@ -1,0 +1,7 @@
+query tag($tagSlug: String, $locale: SiteLocale) {
+  tag(filter: { slug: { eq: $tagSlug } }, locale: $locale) {
+    id
+    title
+    slug
+  }
+}

--- a/src/pages/[language]/blog/tag/[slug]/index.vue
+++ b/src/pages/[language]/blog/tag/[slug]/index.vue
@@ -1,0 +1,5 @@
+<script>
+definePageMeta({ layout: 'content-page' });
+
+export { default } from '../../page/[page].vue'
+</script>

--- a/src/pages/[language]/blog/tag/[slug]/page/[page].vue
+++ b/src/pages/[language]/blog/tag/[slug]/page/[page].vue
@@ -1,0 +1,5 @@
+<script>
+definePageMeta({ layout: 'content-page' });
+
+export { default } from '../../../page/[page].vue'
+</script>

--- a/src/pages/[language]/services/[slug]/index.query.graphql
+++ b/src/pages/[language]/services/[slug]/index.query.graphql
@@ -134,7 +134,7 @@ fragment page on ServiceRecord {
               }
             }
           }
-          ... on StructuredTextTagListRecord {
+          ... on StructuredTextCounterItemListRecord {
             id
             items {
               id

--- a/src/scripts/fetch-i18n-slugs.ts
+++ b/src/scripts/fetch-i18n-slugs.ts
@@ -17,6 +17,10 @@ const operationsWithTranslatedSlugs = [
     route: "language-blog-slug",
     operation: "allBlogPosts",
   },
+  {
+    route: "language-blog-tag-slug",
+    operation: "allTags",
+  },
 ];
 
 // fetches a paginated list of slugs for a given operation

--- a/src/scripts/fetch-routes.ts
+++ b/src/scripts/fetch-routes.ts
@@ -106,7 +106,7 @@ const fetchBlogTagRoutes = async ({ locale }: { locale: string }) => {
       const { data: meta } = await fetchMetaForOperation({
         operation: "allBlogPosts",
         locale,
-        filter: { tags: { anyIn: [tagId] } },
+        filter: `{ tags: { anyIn: ["${tagId}"] } }`,
       });
 
       const { count } = meta[`_allBlogPostsMeta`];
@@ -157,12 +157,17 @@ const fetchMetaForOperation = ({
 }: {
   operation: string;
   locale: string;
-  filter?: Record<string, any> | null;
+  filter?: string | null;
 }) => {
+
+  if (operation === 'allBlogPosts') {
+    console.log(filter)
+  }
+
   return datocmsFetch({
     query: `
         query Meta ($locale: SiteLocale) {
-            _${operation}Meta(locale: $locale, filter: ${gqlFilter(filter)}) {
+            _${operation}Meta(locale: $locale, filter: ${filter}) {
                 count
             }
         }
@@ -217,19 +222,6 @@ const fetchDynamicRoutes = ({
     })
   ).then((data) => data.flat());
 };
-
-// converts an object to a string that can be used as a filter in a GraphQL query
-function gqlFilter(obj: Record<string, any> | null) {
-  if (!obj) {
-    return null;
-  }
-
-  var cleaned = JSON.stringify(obj, null, 2);
-
-  return cleaned.replace(/^[\t ]*"[^:\n\r]+(?<!\\)":/gm, function (match) {
-    return match.replace(/"/g, "");
-  });
-}
 
 export const fetchRoutes = () =>
   Promise.all(

--- a/src/scripts/fetch-routes.ts
+++ b/src/scripts/fetch-routes.ts
@@ -159,11 +159,6 @@ const fetchMetaForOperation = ({
   locale: string;
   filter?: string | null;
 }) => {
-
-  if (operation === 'allBlogPosts') {
-    console.log(filter)
-  }
-
   return datocmsFetch({
     query: `
         query Meta ($locale: SiteLocale) {

--- a/src/scripts/fetch-routes.ts
+++ b/src/scripts/fetch-routes.ts
@@ -63,18 +63,64 @@ const dynamicRoutesConfig: RouteConfig[] = [
     queryOperation: "allPages",
     path: "/",
   },
+  {
+    queryOperation: "allTags",
+    path: "/blog/tag/",
+  },
 ];
 
 // fetches all routes for blog pages for a given locale
-const fetchBlogPagesRoutes = async ({ locale } : { locale: string }) => {
+const fetchBlogPagesRoutes = async ({ locale }: { locale: string }) => {
   const operation = "allBlogPosts";
   const { data: meta } = await fetchMetaForOperation({ operation, locale });
   const { count } = meta[`_${operation}Meta`];
   const pages = Math.ceil(count / BLOG_PER_PAGE);
   return [...Array(pages)]
     .map((_, index) => index + 1)
-    .filter(pageNumber => pageNumber > 1)
+    .filter((pageNumber) => pageNumber > 1)
     .map((pageNumber) => `/${locale}/blog/page/${pageNumber}/`);
+};
+
+// fetches all routes for blog tags for a given locale
+// this needs a separate function because we need to fetch the tag ID for each tag
+// and then calculate the number of pages based on the number of blog posts with that tag
+const fetchBlogTagRoutes = async ({ locale }: { locale: string }) => {
+  const operation = "allTags";
+  const slugs = await fetchSlugsForOperation({ operation, locale });
+  return Promise.all(
+    slugs.map(async (slug) => {
+      const tagId = await datocmsFetch({
+        query: `
+          query TagId($locale: SiteLocale, $slug: String) {
+            tag(locale: $locale, filter: { slug: { eq: $slug } }) {
+              id
+            }
+          }
+        `,
+        variables: {
+          locale,
+          slug,
+        },
+      }).then(({ data }) => data.tag.id);
+
+      const { data: meta } = await fetchMetaForOperation({
+        operation: "allBlogPosts",
+        locale,
+        filter: { tags: { anyIn: [tagId] } },
+      });
+
+      const { count } = meta[`_allBlogPostsMeta`];
+
+      const pages = Math.ceil(count / BLOG_PER_PAGE);
+
+      const paginatedRoutes = [...Array(pages)]
+        .map((_, index) => index + 1)
+        .filter((pageNumber) => pageNumber > 1)
+        .map((pageNumber) => `/${locale}/blog/tag/${slug}/page/${pageNumber}/`);
+
+      return [`/${locale}/blog/tag/${slug}/`, ...paginatedRoutes];
+    })
+  ).then((data) => data.flat());
 };
 
 // fetches a paginated list of slugs for a given operation
@@ -91,6 +137,7 @@ const fetchPaginatedSlugsForOperation = ({
     query: `
         query ${operation}($skip: IntType, $locale: SiteLocale) {
             ${operation}(first: 100, skip: $skip, locale: $locale) {
+                id
                 slug
             }
         }
@@ -106,14 +153,16 @@ const fetchPaginatedSlugsForOperation = ({
 const fetchMetaForOperation = ({
   operation,
   locale,
+  filter = null,
 }: {
   operation: string;
   locale: string;
+  filter?: Record<string, any> | null;
 }) => {
   return datocmsFetch({
     query: `
         query Meta ($locale: SiteLocale) {
-            _${operation}Meta(locale: $locale) {
+            _${operation}Meta(locale: $locale, filter: ${gqlFilter(filter)}) {
                 count
             }
         }
@@ -158,10 +207,29 @@ const fetchDynamicRoutes = ({
         locale,
       });
 
-      return slugs.map((slug) => `/${locale}${path}${slug}/`);
+      return (
+        slugs
+          // some slugs might not exist for some locales,
+          // so we need to filter out any empty values
+          .filter(Boolean)
+          .map((slug) => `/${locale}${path}${slug}/`)
+      );
     })
   ).then((data) => data.flat());
 };
+
+// converts an object to a string that can be used as a filter in a GraphQL query
+function gqlFilter(obj: Record<string, any> | null) {
+  if (!obj) {
+    return null;
+  }
+
+  var cleaned = JSON.stringify(obj, null, 2);
+
+  return cleaned.replace(/^[\t ]*"[^:\n\r]+(?<!\\)":/gm, function (match) {
+    return match.replace(/"/g, "");
+  });
+}
 
 export const fetchRoutes = () =>
   Promise.all(
@@ -174,11 +242,13 @@ export const fetchRoutes = () =>
         });
 
         const blogRoutes = await fetchBlogPagesRoutes({ locale });
+        const blogTagRoutes = await fetchBlogTagRoutes({ locale });
 
         return [
           ...staticRoutesConfig.map((route) => `/${locale}${route}`),
           ...dynamicRoutes,
           ...blogRoutes,
+          ...blogTagRoutes,
         ];
       })
   ).then((data) => data.flat());


### PR DESCRIPTION
# Changes

## Migrations

- Renames 'tag' to 'counter_item'
- Renames 'tag_list' model to 'counter_item_list'
- Creates 'tag' model
- Adds 'tags' field to blog posts

## Code changes

- Adds these extra pages and generates routes for them:
    - /blog/tag/[slug]
    - /blog/tag/[slug]/page/[page]
- Adds tag list to the blog overview page
- Adds tag list to blog post page
- Renames `TagList` to `CounterItemList`

## Notes

🚧 The tags on blog posts in the environment used don't make any sense. I just now added them to test pagination for filtered blog posts. We should re-apply the migrations to a fresh fork of the primary environment before we merge this PR. 