### PR TITLE
fix/redirects-not-always-working

### DIFF
--- a/src/scripts/fetch-redirects.js
+++ b/src/scripts/fetch-redirects.js
@@ -4,7 +4,7 @@ export const fetchRedirects = () => (
   datocmsFetch({
     query: `
       query Redirects {
-        allRedirects {
+        allRedirects(first: 100) {
           from
           to
           httpStatusCode


### PR DESCRIPTION
## What changes were made

- not all redirects were built because of datocms only fetching the first 20 records, I've upped the limit to 100 which should be enough for a good few years

## How to test or check results

<!-- URL or instructions -->

verify that going to `/nl/blog/headless-cmss-go-head-to-head-strapi-vs-datocms/` redirects to `/nl/blog/headless-cmsen-strapi-vs-datocms/`

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
