### PR TITLE
Blog tag enhancements

### DIFF
--- a/migrations/1718094699_addBogTagMetadata.ts
+++ b/migrations/1718094699_addBogTagMetadata.ts
@@ -1,0 +1,115 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create Multiple links field "Related blog posts" (`related_blog_posts`) in model "Blog post" (`blog_post`)'
+  );
+  await client.fields.create("38241", {
+    id: "PaprUQNJRqmQhWpbRXWs6w",
+    label: "Related blog posts",
+    field_type: "links",
+    api_key: "related_blog_posts",
+    localized: true,
+    validators: {
+      items_item_type: {
+        on_publish_with_unpublished_references_strategy: "fail",
+        on_reference_unpublish_strategy: "delete_references",
+        on_reference_delete_strategy: "delete_references",
+        item_types: ["38241"],
+      },
+      size: { min: 0, max: 3 },
+    },
+    appearance: { addons: [], editor: "links_select", parameters: {} },
+  });
+
+  console.log(
+    'Create SEO meta tags field "Blog tag social" (`blog_tag_social`) in model "Tag" (`tag`)'
+  );
+  await client.fields.create("ZCFTBhXpQAG6_zAdrRb7Sw", {
+    id: "c1exEEzwSTaXgK5Uq1aTKQ",
+    label: "Blog tag social",
+    field_type: "seo",
+    api_key: "blog_tag_social",
+    localized: true,
+    validators: {
+      required_seo_fields: {
+        title: true,
+        description: true,
+        image: false,
+        twitter_card: false,
+      },
+      title_length: { max: 60 },
+      description_length: { max: 160 },
+    },
+    appearance: {
+      addons: [],
+      editor: "seo",
+      parameters: {
+        fields: ["title", "description", "image", "no_index", "twitter_card"],
+        previews: [
+          "google",
+          "twitter",
+          "facebook",
+          "linkedin",
+          "slack",
+          "telegram",
+          "whatsapp",
+        ],
+      },
+    },
+  });
+
+  console.log(
+    'Create Single-line string field "Blog topic description" (`blog_topic_description`) in model "Tag" (`tag`)'
+  );
+  await client.fields.create("ZCFTBhXpQAG6_zAdrRb7Sw", {
+    id: "dAMYrpMfRliQyC1Z61ycng",
+    label: "Blog topic description",
+    field_type: "string",
+    api_key: "blog_topic_description",
+    localized: true,
+    validators: { required: {} },
+    appearance: {
+      addons: [],
+      editor: "single_line",
+      parameters: { heading: false },
+    },
+    default_value: { en: "", nl: "" },
+  });
+
+  console.log("Destroy fields in existing models/block models");
+
+  console.log(
+    'Delete SEO meta tags field "Blog Seo" (`blog_seo`) in model "Tag" (`tag`)'
+  );
+  await client.fields.destroy("a32zYvboQJSyqFw3YZgNMg");
+
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update SEO meta tags field "Blog tag social" (`blog_tag_social`) in model "Tag" (`tag`)'
+  );
+  await client.fields.update("c1exEEzwSTaXgK5Uq1aTKQ", { position: 3 });
+
+  console.log(
+    'Update Single-line string field "Blog topic description" (`blog_topic_description`) in model "Tag" (`tag`)'
+  );
+  await client.fields.update("dAMYrpMfRliQyC1Z61ycng", { position: 4 });
+
+  console.log('Update Slug field "Slug" (`slug`) in model "Tag" (`tag`)');
+  await client.fields.update("LUB9rEDZQdyciEdTAhIgWQ", { position: 2 });
+
+  console.log("Finalize models/block models");
+
+  console.log('Update model "Blog post" (`blog_post`)');
+  await client.itemTypes.update("38241", {
+    inverse_relationships_enabled: true,
+  });
+
+  console.log('Update model "Tag" (`tag`)');
+  await client.itemTypes.update("ZCFTBhXpQAG6_zAdrRb7Sw", {
+    inverse_relationships_enabled: true,
+  });
+}

--- a/src/components/app-mobile-menu/app-mobile-menu.vue
+++ b/src/components/app-mobile-menu/app-mobile-menu.vue
@@ -25,7 +25,7 @@
       </span>
     </button>
 
-    <transition-group name="app-mobile-menu-slidein">
+    <transition name="app-mobile-menu-slidein">
       <div
         v-if="isOpen"
         class="app-mobile-menu__content"
@@ -62,7 +62,7 @@
           </li>
         </ul>
       </div>
-    </transition-group>
+    </transition>
   </div>
 </template>
 

--- a/src/components/app-mobile-menu/app-mobile-menu.vue
+++ b/src/components/app-mobile-menu/app-mobile-menu.vue
@@ -5,7 +5,6 @@
       class="app-mobile-menu__button app-mobile-menu__button--open"
       :class="isOpen ? 'app-mobile-menu__button--close' : 'app-mobile-menu__button--open'"
       @click="toggleMenu()"
-      @touchmove="prevent"
     >
       <transition
         name="fade"
@@ -30,7 +29,6 @@
       <div
         v-if="isOpen"
         class="app-mobile-menu__content"
-        @touchmove="prevent"
       >
         <img
           class="app-mobile-menu__logo"
@@ -87,9 +85,6 @@
         this.$nextTick(() => {
           this.$refs.toggleButton.focus()
         })
-      },
-      prevent(event) {
-        event.preventDefault()
       },
     },
   }

--- a/src/composables/useSeoHead.js
+++ b/src/composables/useSeoHead.js
@@ -37,7 +37,10 @@ export function useSeoHead({ title, i18nSlugs, social }) {
       ...$i18n.locales
         .filter(({ code }) => code !== route.params.language)
         .map(({ code }) => {
-          const alternateSlug = i18nSlugs?.find((i18nSlug) => i18nSlug.locale === code).value;
+          const alternateSlug = i18nSlugs?.find((i18nSlug) => i18nSlug.locale === code)?.value;
+          if (!alternateSlug) {
+            return null;
+          }
           const formattedAlternateSlug = alternateSlug?.includes('/') ? alternateSlug.split('/') : alternateSlug
 
           return {

--- a/src/composables/useSeoHead.js
+++ b/src/composables/useSeoHead.js
@@ -35,10 +35,9 @@ export function useSeoHead({ title, i18nSlugs, social }) {
       { rel: 'me', href: mastodonUrl },
       { rel: 'canonical', href: pageUrl },
       ...$i18n.locales
-        .filter(({ code }) => code !== route.params.language)
         .map(({ code }) => {
           const alternateSlug = i18nSlugs?.find((i18nSlug) => i18nSlug.locale === code)?.value;
-          if (!alternateSlug) {
+          if (i18nSlugs && !alternateSlug) {
             return null;
           }
           const formattedAlternateSlug = alternateSlug?.includes('/') ? alternateSlug.split('/') : alternateSlug

--- a/src/composables/useSeoHead.js
+++ b/src/composables/useSeoHead.js
@@ -35,6 +35,7 @@ export function useSeoHead({ title, i18nSlugs, social }) {
       { rel: 'me', href: mastodonUrl },
       { rel: 'canonical', href: pageUrl },
       ...$i18n.locales
+        .filter(({ code }) => code !== route.params.language)
         .map(({ code }) => {
           const alternateSlug = i18nSlugs?.find((i18nSlug) => i18nSlug.locale === code).value;
           const formattedAlternateSlug = alternateSlug?.includes('/') ? alternateSlug.split('/') : alternateSlug

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'blog-topic-meta-data';
+export const datocmsEnvironment = 'tags-fresh';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'tags-fresh';
+export const datocmsEnvironment = 'blog-topic-meta-data';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -141,7 +141,7 @@ fragment page on BlogPostRecord {
     id
     title
     slug
-    blogPosts: _allReferencingBlogPosts {
+    blogPosts: _allReferencingBlogPosts(first: 3) {
       ...blogPostListItem
     }
   }

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -141,7 +141,7 @@ fragment page on BlogPostRecord {
     id
     title
     slug
-    blogPosts: _allReferencingBlogPosts(first: 3) {
+    blogPosts: _allReferencingBlogPosts(first: 3, filter: { slug: { neq: $slug }}) {
       ...blogPostListItem
     }
   }

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -6,6 +6,10 @@ query BlogSlug($locale: SiteLocale, $slug: String) {
 
 fragment page on BlogPostRecord {
   slug
+  i18nSlugs: _allSlugLocales {
+    locale
+    value
+  }
   social {
     title
     description

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -134,10 +134,31 @@ fragment page on BlogPostRecord {
       }
     }
   }
+  relatedBlogPosts {
+    ...blogPostListItem
+  }
   tags {
     id
     title
     slug
+    blogPosts: _allReferencingBlogPosts {
+      ...blogPostListItem
+    }
+  }
+}
+
+fragment blogPostListItem on BlogPostRecord {
+  slug
+  title
+  date: _firstPublishedAt
+  authors {
+    name
+    image {
+      url
+      alt
+      width
+      height
+    }
   }
 }
 

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -167,6 +167,16 @@
           />
         </div>
       </template>
+
+      <section v-if="relatedBlogPosts.length">
+        <h2 class="h3 page-blog-post__related-blog-posts-title">
+          {{ $t('related_blog_posts') }}
+        </h2>
+        <blogs-list
+          :items="relatedBlogPosts"
+          item-size="small"
+        />
+      </section>
     </article>
 
     <div
@@ -190,21 +200,6 @@
       />
       <div class="page-blog-post__scroll-to">
         <scroll-to direction="up" />
-      </div>
-    </section>
-
-    <section
-      class="grid"
-      v-if="relatedBlogPosts.length"
-    >
-      <h2 class="h3 page-blog-post__related-blog-posts-title">
-        {{ $t('related_blog_posts') }}
-      </h2>
-      <div class="grid">
-        <blogs-list
-          :items="relatedBlogPosts"
-          item-size="small"
-        />
       </div>
     </section>
   </main>
@@ -421,10 +416,6 @@
 
     .page-blog-post__archived {
       margin-top: 0;
-    }
-
-    .page-blog-post__related-blog-posts-title {
-      grid-column-start: 16;
     }
   }
 

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -27,7 +27,7 @@
         v-if="tags?.length"
         class="page-blog-post__tags"
       >
-        <h2 class="page-blog-post__tags-title body font-html-blue">
+        <h2 class="sr-only">
           {{ $t('tags') }}
         </h2>
 
@@ -277,7 +277,7 @@
         const tagBlogPosts = tag.blogPosts.filter(tagPost => {
           const outSlugs = out.map(outPost => outPost.slug)
           const alreadyInRelated = outSlugs.includes(tagPost.slug)
-          return (tagPost.slug !== data.value.page.slug && !alreadyInRelated)
+          return !alreadyInRelated
         });
 
         out = out.concat(tagBlogPosts);
@@ -316,12 +316,7 @@
   }
 
   .page-blog-post__tags {
-    margin-top: var(--spacing-small);
-    margin-bottom: var(--spacing-small);
-  }
-
-  .page-blog-post__tags-title {
-    margin-bottom: var(--spacing-small);
+    margin-top: var(--spacing-large);
   }
 
   .page-blog-post__link-container {

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -193,7 +193,10 @@
       </div>
     </section>
 
-    <section class="grid">
+    <section
+      class="grid"
+      v-if="relatedBlogPosts.length"
+    >
       <h2 class="h3 page-blog-post__related-blog-posts-title">
         {{ $t('related_blog_posts') }}
       </h2>

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -22,6 +22,18 @@
         :twitter-title="data.page.title"
         :authors="data.page.authors"
       />
+
+      <div
+        v-if="tags?.length"
+        class="page-blog-post__tags"
+      >
+        <h2 class="page-blog-post__tags-title body font-html-blue">
+          {{ $t('tags') }}
+        </h2>
+
+        <tag-list :items="tags" />
+      </div>
+
       <toc-section :items="tocItems" />
     </aside>
 
@@ -181,15 +193,16 @@
       </div>
     </section>
 
-    <section
-      v-if="tags?.length"
-      class="page-blog-post__tags"
-    >
-      <h2 class="h4 page-blog-post__tags-title">
-        {{ $t('read_more_on') }}
+    <section class="grid">
+      <h2 class="h3 page-blog-post__related-blog-posts-title">
+        {{ $t('related_blog_posts') }}
       </h2>
-
-      <tag-list :items="tags" />
+      <div class="grid">
+        <blogs-list
+          :items="relatedBlogPosts"
+          item-size="small"
+        />
+      </div>
     </section>
   </main>
 </template>
@@ -257,6 +270,26 @@
       }
     })
   });
+
+  const relatedBlogPosts = computed(() => {
+    let concatenatedRelatedBlogPosts = data.value.page.relatedBlogPosts;
+
+    if (concatenatedRelatedBlogPosts.length < 3) {
+      concatenatedRelatedBlogPosts = data.value.page.tags.reduce((out, tag) => {
+        const tagBlogPosts = tag.blogPosts.filter(tagPost => {
+          const outSlugs = out.map(outPost => outPost.slug)
+          const alreadyInRelated = outSlugs.includes(tagPost.slug)
+          return (tagPost.slug !== data.value.page.slug && !alreadyInRelated)
+        });
+
+        out = out.concat(tagBlogPosts);
+
+        return out
+      }, concatenatedRelatedBlogPosts)
+    }
+
+    return concatenatedRelatedBlogPosts.slice(0, 3);
+  });
 </script>
 
 <style>
@@ -285,12 +318,12 @@
   }
 
   .page-blog-post__tags {
-    grid-row: 4;
-    padding-bottom: var(--spacing-large);
+    margin-top: var(--spacing-small);
+    margin-bottom: var(--spacing-small);
   }
 
   .page-blog-post__tags-title {
-    margin-bottom: var(--spacing-medium);
+    margin-bottom: var(--spacing-small);
   }
 
   .page-blog-post__link-container {
@@ -341,9 +374,12 @@
     margin-top: var(--spacing-medium);
   }
 
+  .page-blog-post__related-blog-posts-title {
+    margin-bottom: var(--spacing-medium);
+  }
+
   @media (min-width: 720px) {
-    .page-blog-post-list > *,
-    .page-blog-post__tags {
+    .page-blog-post-list > * {
       margin-bottom: var(--spacing-larger);
       padding: 0 var(--spacing-larger);
     }
@@ -361,8 +397,7 @@
       grid-row: 2;
     }
 
-    .page-blog-post-list,
-    .page-blog-post__tags {
+    .page-blog-post-list {
       grid-column-start: 10;
       grid-column-end: 50;
     }
@@ -384,16 +419,18 @@
     .page-blog-post__archived {
       margin-top: 0;
     }
+
+    .page-blog-post__related-blog-posts-title {
+      grid-column-start: 16;
+    }
   }
 
   @media (min-width: 1100px) {
-    .page-blog-post-list > *,
-    .page-blog-post__tags {
+    .page-blog-post-list > * {
       padding: 0 var(--spacing-big);
     }
 
-    .page-blog-post-list,
-    .page-blog-post__tags {
+    .page-blog-post-list {
       grid-column-start: 12;
       grid-column-end: 46;
     }
@@ -405,19 +442,13 @@
   }
 
   @media (min-width: 1440px) {
-    .page-blog-post-list > *,
-    .page-blog-post__tags {
+    .page-blog-post-list > * {
       padding: 0 var(--spacing-bigger);
     }
 
-    .page-blog-post-list,
-    .page-blog-post__tags {
+    .page-blog-post-list {
       grid-column-start: 12;
       grid-column-end: 44;
-    }
-
-    .page-blog-post__tags {
-      margin-bottom: var(--spacing-large);
     }
   }
 </style>

--- a/src/pages/[language]/blog/page/[page].vue
+++ b/src/pages/[language]/blog/page/[page].vue
@@ -18,7 +18,7 @@
 
         <text-block class="page-blog__text">
           <p class="testimonial">
-            {{ pageData.page.description }}
+            {{ pageData.tag?.blogTopicDescription || pageData.page.description }}
           </p>
         </text-block>
 
@@ -99,7 +99,7 @@
     return (currentPage.value - 1) * PER_PAGE;
   });
 
-  let tagId = undefined
+  let tagId = ''
 
   if (params.slug) {
     const { data: tagData } = await useFetchContent({
@@ -111,7 +111,7 @@
       }
     });
 
-    tagId = tagData.value?.tag?.id;
+    tagId = tagData.value?.tag?.id || '';
   }
 
   const tagFilter = tagId ? {
@@ -156,7 +156,15 @@
   // Only show pinned posts on the first page and if no tag is selected
   const shouldShowPinnedPosts = currentPage.value === 1 && !tagId;
 
-  useSeoHead(pageData.value.page);
+  const seoHeadData = pageData.value.tag
+    ? {
+      title: pageData.value.tag.title,
+      i18nSlugs: pageData.value.tag.i18nSlugs,
+      social: pageData.value.tag.blogTopicSocial,
+    }
+    : pageData.value.page;
+
+  useSeoHead(seoHeadData);
 
   function getPaginatedRoute(pageNumber) {
     if (pageNumber === 1) {
@@ -207,6 +215,7 @@
   .page-blog__pagination {
     grid-row: 4;
     margin: auto;
+    margin-bottom: var(--spacing-small);
   }
 
   .page-blog__pivots {

--- a/src/pages/[language]/blog/page/[page].vue
+++ b/src/pages/[language]/blog/page/[page].vue
@@ -160,7 +160,7 @@
     ? {
       title: pageData.value.tag.title,
       i18nSlugs: pageData.value.tag.i18nSlugs,
-      social: pageData.value.tag.blogTopicSocial,
+      social: pageData.value.tag.blogTagSocial,
     }
     : pageData.value.page;
 

--- a/src/pages/[language]/blog/page/index.query.graphql
+++ b/src/pages/[language]/blog/page/index.query.graphql
@@ -44,7 +44,7 @@ query Blog(
     id
     title
     slug
-    blogTopicSocial {
+    blogTagSocial {
       title
       description
       image {

--- a/src/pages/[language]/blog/page/index.query.graphql
+++ b/src/pages/[language]/blog/page/index.query.graphql
@@ -37,9 +37,24 @@ query Blog(
     slug
   }
   tag: tag(filter: { id: { eq: $tagId } }) {
+    i18nSlugs: _allSlugLocales {
+      locale
+      value
+    }
     id
     title
     slug
+    blogTopicSocial {
+      title
+      description
+      image {
+        id
+        width
+        height
+        url
+      }
+    }
+    blogTopicDescription
   }
 }
 


### PR DESCRIPTION
## What changes were made

- Blog topic overview pages should be able to set their own seo stuff and description.
- Blogs can have related blogs, if none are set, we take the last 3 from related tags. There are always a maximum of 3.
- Moved the tags list into the "sidebar", I think it makes more sense since it is some sort of meta data. Plus it was interfering with related blog posts at the bottom.
 
## How to test or check results

See blog overview pages, blog topic overview pages and individual blog posts
