### PR TITLE
feat/improve-blog-post-headings

### DIFF
--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -130,8 +130,8 @@
             v-if="item.title"
             class="page-blog-post-list__title font-html-blue"
             :class="`
-              h${item.headingLevel || defaultHeadingLevel}
-              page-blog-post-list__title--h${item.headingLevel || defaultHeadingLevel}
+              ${headingClassMap[item.headingLevel || defaultHeadingLevel]}
+              page-blog-post-list__title--${headingClassMap[item.headingLevel || defaultHeadingLevel]}
             `"
             :is="`h${item.headingLevel || defaultHeadingLevel}`"
             :id="item.titleId"
@@ -209,6 +209,13 @@
   const { $localeUrl } = useNuxtApp();
 
   const defaultHeadingLevel = 3;
+  const headingClassMap = {
+    2: 'h3',
+    3: 'h4',
+    4: 'h5',
+    5: 'h6',
+    6: 'h6',
+  }
 
   const runtimeConfig = useRuntimeConfig();
 
@@ -288,11 +295,55 @@
   }
 
   .page-blog-post-list__title--h5 {
-    font-size: 1.0625rem; /* 17px */
+    font-size: 1.0625rem; /* 15px */
   }
 
   .page-blog-post-list__title--h6 {
-    font-size: .9375rem; /* 15px */
+    font-size: 0.6875rem; /* 11px */
+  }
+
+  @media (min-width: 720px) {
+    .page-blog-post-list__title--h2 {
+      font-size: 2.5rem; /* 35px */
+    }
+
+    .page-blog-post-list__title--h3 {
+      font-size: 2.1875rem; /* 35px */
+    }
+
+    .page-blog-post-list__title--h4 {
+      font-size: 1.4375rem; /* 23px */
+    }
+
+    .page-blog-post-list__title--h5 {
+      font-size: 1rem; /* 16px */
+    }
+
+    .page-blog-post-list__title--h6 {
+      font-size: 0.75rem; /* 12px */
+    }
+  }
+
+  @media (min-width: 1100px) {
+    .page-blog-post-list__title--h2 {
+      font-size: 2.8125rem; /* 45px */
+    }
+
+    .page-blog-post-list__title--h3 {
+      font-size: 2.5rem; /* 40px */
+    }
+
+    .page-blog-post-list__title--h4 {
+      font-size: 1.75rem; /* 28px */
+    }
+
+    .page-blog-post-list__title--h5 {
+      font-size: 1.75rem; /* 18px */
+    }
+
+    .page-blog-post-list__title--h6 {
+      font-size: 1.75rem; /* 13px */
+    }
   }
 
   .page-blog-post__aside {

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -366,7 +366,7 @@
 
   @media (min-width: 720px) {
     .page-blog-post-list__title--h2 {
-      font-size: 2.5rem; /* 35px */
+      font-size: 2.5rem; /* 40px */
     }
 
     .page-blog-post-list__title--h3 {

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -302,50 +302,6 @@
     font-size: 0.6875rem; /* 11px */
   }
 
-  @media (min-width: 720px) {
-    .page-blog-post-list__title--h2 {
-      font-size: 2.5rem; /* 35px */
-    }
-
-    .page-blog-post-list__title--h3 {
-      font-size: 2.1875rem; /* 35px */
-    }
-
-    .page-blog-post-list__title--h4 {
-      font-size: 1.4375rem; /* 23px */
-    }
-
-    .page-blog-post-list__title--h5 {
-      font-size: 1rem; /* 16px */
-    }
-
-    .page-blog-post-list__title--h6 {
-      font-size: 0.75rem; /* 12px */
-    }
-  }
-
-  @media (min-width: 1100px) {
-    .page-blog-post-list__title--h2 {
-      font-size: 2.8125rem; /* 45px */
-    }
-
-    .page-blog-post-list__title--h3 {
-      font-size: 2.5rem; /* 40px */
-    }
-
-    .page-blog-post-list__title--h4 {
-      font-size: 1.75rem; /* 28px */
-    }
-
-    .page-blog-post-list__title--h5 {
-      font-size: 1.75rem; /* 18px */
-    }
-
-    .page-blog-post-list__title--h6 {
-      font-size: 1.75rem; /* 13px */
-    }
-  }
-
   .page-blog-post__aside {
     justify-content: space-between;
     grid-row: 2;
@@ -409,6 +365,26 @@
   }
 
   @media (min-width: 720px) {
+    .page-blog-post-list__title--h2 {
+      font-size: 2.5rem; /* 35px */
+    }
+
+    .page-blog-post-list__title--h3 {
+      font-size: 2.1875rem; /* 35px */
+    }
+
+    .page-blog-post-list__title--h4 {
+      font-size: 1.4375rem; /* 23px */
+    }
+
+    .page-blog-post-list__title--h5 {
+      font-size: 1rem; /* 16px */
+    }
+
+    .page-blog-post-list__title--h6 {
+      font-size: 0.75rem; /* 12px */
+    }
+
     .page-blog-post-list > *,
     .page-blog-post__tags {
       margin-bottom: var(--spacing-larger);
@@ -454,6 +430,26 @@
   }
 
   @media (min-width: 1100px) {
+    .page-blog-post-list__title--h2 {
+      font-size: 2.8125rem; /* 45px */
+    }
+
+    .page-blog-post-list__title--h3 {
+      font-size: 2.5rem; /* 40px */
+    }
+
+    .page-blog-post-list__title--h4 {
+      font-size: 1.75rem; /* 28px */
+    }
+
+    .page-blog-post-list__title--h5 {
+      font-size: 1.75rem; /* 18px */
+    }
+
+    .page-blog-post-list__title--h6 {
+      font-size: 1.75rem; /* 13px */
+    }
+
     .page-blog-post-list > *,
     .page-blog-post__tags {
       padding: 0 var(--spacing-big);

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -130,8 +130,8 @@
             v-if="item.title"
             class="page-blog-post-list__title font-html-blue"
             :class="`
-              ${headingClassMap[item.headingLevel || defaultHeadingLevel]}
-              page-blog-post-list__title--${headingClassMap[item.headingLevel || defaultHeadingLevel]}
+              ${headingLevelClassMap[item.headingLevel || defaultHeadingLevel]}
+              page-blog-post-list__title--${headingLevelClassMap[item.headingLevel || defaultHeadingLevel]}
             `"
             :is="`h${item.headingLevel || defaultHeadingLevel}`"
             :id="item.titleId"
@@ -209,7 +209,7 @@
   const { $localeUrl } = useNuxtApp();
 
   const defaultHeadingLevel = 3;
-  const headingClassMap = {
+  const headingLevelClassMap = {
     2: 'h3',
     3: 'h4',
     4: 'h5',

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -129,7 +129,10 @@
           <component
             v-if="item.title"
             class="page-blog-post-list__title font-html-blue"
-            :class="headingLevelClassMap[item.headingLevel || defaultHeadingLevel]"
+            :class="`
+              h${item.headingLevel || defaultHeadingLevel}
+              page-blog-post-list__title--h${item.headingLevel || defaultHeadingLevel}
+            `"
             :is="`h${item.headingLevel || defaultHeadingLevel}`"
             :id="item.titleId"
           >
@@ -207,13 +210,6 @@
 
   const defaultHeadingLevel = 3;
 
-  const headingLevelClassMap = {
-    2: 'h3',
-    3: 'h4',
-    4: 'h5',
-    5: 'h6',
-  }
-
   const runtimeConfig = useRuntimeConfig();
 
   const { params } = useRoute();
@@ -259,7 +255,7 @@
   });
 </script>
 
-<style>
+<style scoped>
   .page-blog-post__header,
   .page-blog-post__aside-author,
   .page-blog-post__button {
@@ -277,6 +273,26 @@
 
   .page-blog-post-list__title {
     margin-bottom: var(--spacing-smaller);
+  }
+
+  .page-blog-post-list__title--h2 {
+    font-size: 2.1875rem; /* 35px */
+  }
+
+  .page-blog-post-list__title--h3 {
+    font-size: 1.75rem; /* 28px */
+  }
+
+  .page-blog-post-list__title--h4 {
+    font-size: 1.3125rem; /* 21px */
+  }
+
+  .page-blog-post-list__title--h5 {
+    font-size: 1.0625rem; /* 17px */
+  }
+
+  .page-blog-post-list__title--h6 {
+    font-size: .9375rem; /* 15px */
   }
 
   .page-blog-post__aside {


### PR DESCRIPTION
## What changes were made

The blog posts had a heading mapping that caused some issues. Each blog posts exists of multiple text-record blocks which include a explicit title field and a rich-text field (which can also include all heading levels). The explicit titles were being mapped to always be shown as a level smaller, but this sometimes caused the explicit title to be the exact same size visually as the next heading in the rich text.
E.g if the explicit title is level 2, but due to the mapping, is being rendered as a h3, and if the rich text starts with a heading that is also level 3 --> then both these headings would have the same size and look visually identical, even though one of the headings is a h2 and the other is a h3 (this scenario is shown in the screenshot below).

![Screenshot 2024-06-10 at 16 19 34](https://github.com/voorhoede/voorhoede-website/assets/45405413/d8efc1ad-a98c-4019-b368-5d260b72e294)

To prevent this, me and Vera came up with the idea to adjust the blog post heading font-sizes to be unique -- this means they do not match the .h1-.h6 classes that we have specified in the typography.css file and thus never clash with the rich-text headings. But this does mean that we make an exception for the heading sizes in the blog posts. 

## How to test or check results

- check the blog posts
<!-- URL or instructions -->

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
