### PR TITLE
refactor/blog-headings

### DIFF
--- a/migrations/1718371026_removeHeadingLevelFromTextRecords.ts
+++ b/migrations/1718371026_removeHeadingLevelFromTextRecords.ts
@@ -1,0 +1,10 @@
+import { Client, SimpleSchemaTypes } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Destroy fields in existing models/block models");
+
+  console.log(
+    'Delete Single-line string field "Heading Level" (`heading_level`) in block model "Text Section" (`text_section`)'
+  );
+  await client.fields.destroy("10438932");
+}

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'youtube-cookie-notice-deploy';
+export const datocmsEnvironment = 'blog-headings';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'blog-headings';
+export const datocmsEnvironment = 'blog-headings-deploy';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/blog/[slug]/index.query.graphql
+++ b/src/pages/[language]/blog/[slug]/index.query.graphql
@@ -104,7 +104,6 @@ fragment page on BlogPostRecord {
     ... on TextSectionRecord {
       id
       title
-      headingLevel
       body
     }
   }

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -126,15 +126,13 @@
           :key="item.id"
           class="page-blog-post-list__text"
         >
-          <component
+          <h2
             v-if="item.title"
-            class="page-blog-post-list__title font-html-blue"
-            :class="headingLevelClassMap[item.headingLevel || defaultHeadingLevel]"
-            :is="`h${item.headingLevel || defaultHeadingLevel}`"
+            class="page-blog-post-list__title font-html-blue h2"
             :id="item.titleId"
           >
             {{ item.title }}
-          </component>
+          </h2>
           <rich-text-block
             v-if="item.body"
             :text="item.body"
@@ -204,15 +202,6 @@
   import('prismjs/components/prism-rust');
 
   const { $localeUrl } = useNuxtApp();
-
-  const defaultHeadingLevel = 3;
-
-  const headingLevelClassMap = {
-    2: 'h3',
-    3: 'h4',
-    4: 'h5',
-    5: 'h6',
-  }
 
   const runtimeConfig = useRuntimeConfig();
 


### PR DESCRIPTION
This PR replaces the old https://github.com/voorhoede/voorhoede-website/pull/804 PR. 

## What changes were made

- remove heading mapping in blog posts, titles should always be rendered as a h2, you can use h3-h6 for the richt text headings

## How to test or check results

<!-- URL or instructions -->

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
