### PR TITLE
fix: always make video-notice same size as video itself

### DIFF
--- a/src/components/youtube-cookie-notice/youtube-cookie-notice.vue
+++ b/src/components/youtube-cookie-notice/youtube-cookie-notice.vue
@@ -66,9 +66,7 @@ const setInLocalStorage = (key: string, state: any) => localStorage.setItem(key,
 .notice {
   display: grid;
   align-content: center;
-  inline-size: 100%;
   aspect-ratio: v-bind(aspectRatio);
-  max-inline-size: var(--case-content-max-width-l);
   background-color: var(--paper);
 }
 

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -326,9 +326,14 @@
     font-style: italic;
   }
 
-  .page-blog-post-list .responsive-video {
-    width: 100%;
-    max-width: var(--case-content-max-width-l);
+  .page-blog-post-list .responsive-video,
+  .page-blog-post-list .notice {
+    max-inline-size: var(--case-content-max-width-l);
+  }
+
+  .page-blog-post-list .notice {
+    padding: unset;
+    margin-inline: var(--spacing-bigger);
   }
 
   .page-blog-post__archived {

--- a/src/pages/[language]/cases/[slug]/index.vue
+++ b/src/pages/[language]/cases/[slug]/index.vue
@@ -232,7 +232,8 @@
     margin-right: calc(-1 * var(--spacing-small));
   }
 
-  .page-case__content .responsive-video {
+  .page-case__content .responsive-video,
+  .page-case__content .notice {
     width: 100%;
     max-width: var(--case-content-max-width-l);
   }

--- a/src/pages/[language]/events/[slug]/index.vue
+++ b/src/pages/[language]/events/[slug]/index.vue
@@ -282,7 +282,8 @@
     max-width: 100%;
   }
 
-  .page-event-detail__main .responsive-video {
+  .page-event-detail__main .responsive-video,
+  .page-event-detail__main .notice {
     width: 100%;
     max-width: var(--case-content-max-width-l);
   }

--- a/src/pages/[language]/services/[slug]/index.vue
+++ b/src/pages/[language]/services/[slug]/index.vue
@@ -150,6 +150,7 @@
   .page-service__structured-text-section,
   .page-service__overview .blockquote-block,
   .page-service__overview > .responsive-video,
+  .page-service__overview > .notice,
   .page-service__overview .cases-list {
     margin: 0 0 var(--spacing-large) 0;
   }
@@ -207,6 +208,7 @@
 
     .page-service__overview > .image-with-caption,
     .page-service__overview > .responsive-video,
+    .page-service__overview > .notice,
     .page-service__overview > .testimonial-block {
       width: 70%;
     }


### PR DESCRIPTION
## What changes were made

- always make video-notice same size as video itself

## How to test or check results

<!-- URL or instructions -->
verify that the size is the same for the notice and video
- /en/services/design-system/
- /en/blog/digital-healthcare-cure-with-package-leaflet/
- /en/cases/quantum-inspire/


## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
