### PR TITLE
Fix infinite redirect loop caused by index files

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,10 +22,10 @@ export default defineNuxtConfig({
       concurrency: 35, // stay below 40 to avoid rate limiting
       interval: 1000, // use 1 second interval to avoid rate limiting
       failOnError: false,
+      autoSubfolderIndex: false,
     },
     routeRules: {
       '/': { prerender: false },
-      '/*/blog/': { prerender: false },
       '/blog-feed.xml': {
         redirect: { to: '/blog/feed.json', statusCode: 301 },
       },

--- a/src/composables/useSeoHead.js
+++ b/src/composables/useSeoHead.js
@@ -11,7 +11,7 @@ export function useSeoHead({ title, i18nSlugs, social }) {
   const route = useRoute();
   const router = useRouter();
 
-  const pageUrl = new URL(route.path, runtimeConfig.public.baseUrl).toString();
+  const pageUrl = withTrailingSlash(new URL(route.path, runtimeConfig.public.baseUrl).toString());
   const defaultShareImg = new URL('/images/logo-wide.jpg', runtimeConfig.public.baseUrl).toString();
 
   useHead({

--- a/src/middleware/trailing-slash.global.ts
+++ b/src/middleware/trailing-slash.global.ts
@@ -1,7 +1,10 @@
-import { withTrailingSlash } from "ufo";
+import { withTrailingSlash } from 'ufo';
 
 export default defineNuxtRouteMiddleware((to, from) => {
-  if (!to.path.endsWith("/")) {
-    return navigateTo(withTrailingSlash(to.fullPath, true));
+  if (!to.path.endsWith('/')) {
+    return navigateTo(
+      withTrailingSlash(to.fullPath, true),
+      { redirectCode: 308 },
+    );
   }
 });


### PR DESCRIPTION
To match Cloudflare route matching rules, set the nitro option
`autoSubfolderIndex` to `false`. Odd issue that only showed itself on
certain pages, unsure why but `/en/contact/` redirected to itself.
