### PR TITLE
FEAT: Pipedrive add contact source upon subscribing

### DIFF
--- a/server/api/newsletter.post.ts
+++ b/server/api/newsletter.post.ts
@@ -1,3 +1,5 @@
+import { createPipedriveClient, type PipedriveClient } from '../lib/pipedrive';
+
 const FAILED_REDIRECT = 'contact/failed/';
 const CONFIRMATION_REDIRECT = 'contact/thank-you/';
 
@@ -15,81 +17,52 @@ export default defineEventHandler(async (event) => {
     );
     return sendRedirect(event, `/${locale}/${FAILED_REDIRECT}`);
   }
-  await subscribe(
-    { name, email, consent },
-    { api_token: config.pipedriveApiToken, url: config.pipedriveApiUrl }
-  )
-    .then(() => {
-      return sendRedirect(event, `/${locale}/${CONFIRMATION_REDIRECT}`, 303);
-    })
-    .catch((error) => {
-      console.error(
-        'Error subscribing user',
-        error
-      );
-      return sendRedirect(event, `/${locale}/${FAILED_REDIRECT}`);
-    });
+
+  const pipedriveClient = createPipedriveClient({
+    api_token: config.pipedriveApiToken,
+    url: config.pipedriveApiUrl
+  });
+
+  try {
+    await subscribe(pipedriveClient, { name, email, consent });
+    return sendRedirect(event, `/${locale}/${CONFIRMATION_REDIRECT}`, 303);
+  } catch (error) {
+    console.error('Error subscribing user', error);
+    return sendRedirect(event, `/${locale}/${FAILED_REDIRECT}`);
+  }
 });
 
-/**
- * The API key for the 'Contact Source' field.
- * This API key is can be checked in the Pipedrive UI.
- */
-const CONTACT_SOURCE_FIELD_APIKEY = "777843b709aa29ae549063f689f7a6bd4c06b481";
-
-/**
- * The ID of the 'Newsletter (Website)' option in the 'Contact Source' field.
- * This ID is cannot be checked in the Pipedrive UI.
- * Based on light testing with removing and adding option fields, I assume this ID will remain the same but there is no guarantee.
- */
-const NEWSLETTER_OPTION_ID = 309;
-
-async function existingUserIdByEmail(
-  { email }: { email: string },
-  { api_token, url }: { api_token: string, url: string }
-) {
-  const params = new URLSearchParams({
-    term: email,
-    fields: 'email',
-    exact_match: 'true',
-    api_token,
-  });
-  const result = await fetch(
-    new URL(`${url}/v1/persons/search?${params.toString()}`)
-  ).then(response => response.json());
-  return result.data?.items?.[0]?.item?.id || null;
-}
-
 async function subscribe(
-  { name, email, consent }: { name: string, email: string, consent: boolean },
-  { api_token, url }: { api_token: string, url: string }
+  pipedriveClient: PipedriveClient,
+  { name, email, consent }: { name: string, email: string, consent: boolean }
 ) {
-  const id = await existingUserIdByEmail({ email }, { api_token, url });
-  const params = new URLSearchParams({ api_token });
+  const contactSourceFieldApiKey = pipedriveClient.getContactSourceFieldApiKey();
+  const newsletterOptionId = pipedriveClient.getNewsletterOptionId();
+  const personId = await pipedriveClient.findPersonByEmail({ email });
 
-  if (id) {
+  if (personId) {
     // Do not update the user if they do not give consent
-    if (!consent) { return }
+    if (!consent) {
+      return;
+    }
+
     // If the user already exists, update their marketing status
-    return fetch(`${url}/v2/persons/${id}?${params}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    return pipedriveClient.updatePerson({
+      personId,
+      updates: {
         marketing_status: 'subscribed',
-        [CONTACT_SOURCE_FIELD_APIKEY]: NEWSLETTER_OPTION_ID,
-      }),
+        [contactSourceFieldApiKey]: newsletterOptionId,
+      },
     });
   }
 
   // If the user does not exist, create a new person
-  return fetch(`${url}/v1/persons?${params}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
+  return pipedriveClient.createPerson({
+    personData: {
       name,
       email: [{ value: email, primary: true, label: 'work' }],
       marketing_status: consent ? 'subscribed' : 'no_consent',
-      [CONTACT_SOURCE_FIELD_APIKEY]: NEWSLETTER_OPTION_ID,
-    }),
+      [contactSourceFieldApiKey]: newsletterOptionId,
+    }
   });
 }

--- a/server/lib/pipedrive.ts
+++ b/server/lib/pipedrive.ts
@@ -1,0 +1,162 @@
+interface PipedriveConfig {
+  api_token: string;
+  url: string;
+}
+
+export class PipedriveClient {
+  private config: PipedriveConfig;
+  private contactSourceFieldApiKey: string;
+  private newsletterOptionId: number;
+
+  constructor(config: PipedriveConfig) {
+    this.config = config;
+    this.contactSourceFieldApiKey = "777843b709aa29ae549063f689f7a6bd4c06b481";
+    this.newsletterOptionId = 309;
+  }
+
+  getContactSourceFieldApiKey(): string {
+    return this.contactSourceFieldApiKey;
+  }
+
+  getNewsletterOptionId(): number {
+    return this.newsletterOptionId;
+  }
+
+  private getParams(): URLSearchParams {
+    return new URLSearchParams({ api_token: this.config.api_token });
+  }
+
+  private async makeRequest<T>(
+    endpoint: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const params = this.getParams();
+    const url = `${this.config.url}${endpoint}?${params}`;
+
+    const response = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+      ...options,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Pipedrive API error: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async getPersonDetails(params: { personId: number }): Promise<any> {
+    return this.makeRequest(`/v2/persons/${params.personId}`, {
+      method: "GET",
+    });
+  }
+
+  /**
+   * Search for an existing person by email
+   */
+  async findPersonByEmail(params: { email: string }): Promise<number | null> {
+    const searchParams = new URLSearchParams({
+      term: params.email,
+      fields: "email",
+      exact_match: "true",
+      api_token: this.config.api_token,
+    });
+
+    const result = await fetch(
+      new URL(
+        `${this.config.url}/v1/persons/search?${searchParams.toString()}`,
+      ),
+    ).then((response) => response.json());
+
+    return result.data?.items?.[0]?.item?.id || null;
+  }
+
+  /**
+   * Create a new person in Pipedrive
+   */
+  async createPerson(params: {
+    personData: Record<string, any>;
+  }): Promise<any> {
+    return this.makeRequest("/v1/persons", {
+      method: "POST",
+      body: JSON.stringify(params.personData),
+    });
+  }
+
+  /**
+   * Update an existing person in Pipedrive
+   */
+  async updatePerson(params: {
+    personId: number;
+    updates: Record<string, any>;
+  }): Promise<any> {
+    return this.makeRequest(
+      `/v1/persons/${params.personId}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(params.updates),
+      },
+    );
+  }
+
+  /**
+   * Create a new organization in Pipedrive
+   */
+  async createOrganization(params: {
+    name: string;
+    owner_id?: number;
+    [key: string]: any;
+  }): Promise<any> {
+    return this.makeRequest("/v1/organizations", {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+  }
+
+  /**
+   * Update an existing organization in Pipedrive
+   */
+  async updateOrganization(params: {
+    organizationId: number;
+    updates: Record<string, any>;
+  }): Promise<any> {
+    return this.makeRequest(`/v1/organizations/${params.organizationId}`, {
+      method: "PATCH",
+      body: JSON.stringify(params.updates),
+    });
+  }
+
+  /**
+   * Search for an existing organization by name
+   */
+  async findOrganizationByName(params: {
+    name: string;
+  }): Promise<number | null> {
+    const searchParams = new URLSearchParams({
+      term: params.name,
+      fields: "name",
+      exact_match: "true",
+      api_token: this.config.api_token,
+    });
+
+    const result = await fetch(
+      new URL(
+        `${this.config.url}/v1/organizations/search?${searchParams.toString()}`,
+      ),
+    ).then((response) => response.json());
+
+    return result.data?.items?.[0]?.item?.id || null;
+  }
+}
+
+/**
+ * Factory function to create a Pipedrive client instance
+ */
+export function createPipedriveClient(config: PipedriveConfig): PipedriveClient {
+  return new PipedriveClient(config);
+}


### PR DESCRIPTION
## What changes were made
- add 'Contact Source' with 'Newsletter (Website)' option in pipedrive at the request of Marketing team.
- interact with PipeDrive upon form submission
- create PipeDrive client in separate file to keep things organized and future proof.

I've tested wheter
- field IDs change upon reordering of field options
- field IDs change upon adding or deleting another field

The field ID seems to remain intact as long as the field in question doesn't get deleted.

## How to test or check results
1. ask marketing team if testing is ok
2. subscribe to the newsletter and see if pipedrive data is updated

<!-- URL or instructions -->

## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [ ] Appointed PR reviewers
