### PR TITLE
feature: footer separate certificate mapping logic

### DIFF
--- a/migrations/1775740612_addFooterCertificatesGrid.ts
+++ b/migrations/1775740612_addFooterCertificatesGrid.ts
@@ -1,0 +1,149 @@
+import type { Client } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Create new models/block models");
+
+  console.log('Create block model "Menu Item" (`menu_item`)');
+  await client.itemTypes.create(
+    {
+      id: "F3_9OXD7SVmcNnbSpj1yGg",
+      name: "Menu Item",
+      api_key: "menu_item",
+      modular_block: true,
+      draft_saving_active: false,
+      hint: "",
+      inverse_relationships_enabled: false,
+    },
+    {
+      skip_menu_item_creation: true,
+      schema_menu_item_id: "XIFAxFYFRtq35uE-qKP8ZA",
+    },
+  );
+
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create Modular Content (Single block) field "Link" (`link`) in block model "Menu Item" (`menu_item`)',
+  );
+  await client.fields.create("F3_9OXD7SVmcNnbSpj1yGg", {
+    id: "KiG_qn-oQ4CHhOpnzAhrwQ",
+    label: "Link",
+    field_type: "single_block",
+    api_key: "link",
+    validators: {
+      single_block_blocks: { item_types: ["2034503", "2037919"] },
+      required: {},
+    },
+    appearance: {
+      addons: [],
+      editor: "framed_single_block",
+      parameters: { start_collapsed: false },
+    },
+    default_value: null,
+  });
+
+  console.log(
+    'Create Single asset field "Image" (`image`) in block model "Menu Item" (`menu_item`)',
+  );
+  await client.fields.create("F3_9OXD7SVmcNnbSpj1yGg", {
+    id: "Wc-VzQQTQrqc7mWfzpkN1A",
+    label: "Image",
+    field_type: "file",
+    api_key: "image",
+    validators: { required_alt_title: { title: false, alt: true } },
+    appearance: { addons: [], editor: "file", parameters: {} },
+    default_value: null,
+  });
+
+  console.log('Create fieldset "Certificates" in model "Footer" (`footer`)');
+  await client.fieldsets.create("47595", {
+    id: "PvqIQFN4S1C_cbXc9vc-9g",
+    title: "Certificates",
+    collapsible: true,
+    start_collapsed: true,
+  });
+
+  console.log(
+    'Create Modular Content (Multiple blocks) field "Certificates Grid" (`certificates_grid`) in model "Footer" (`footer`)',
+  );
+  await client.fields.create("47595", {
+    id: "F4MXL-00Sr-KfJn_gQAKYA",
+    label: "Certificates Grid",
+    field_type: "rich_text",
+    api_key: "certificates_grid",
+    validators: {
+      rich_text_blocks: { item_types: ["F3_9OXD7SVmcNnbSpj1yGg"] },
+    },
+    appearance: {
+      addons: [],
+      editor: "rich_text",
+      parameters: { start_collapsed: false },
+    },
+    default_value: null,
+    fieldset: { id: "PvqIQFN4S1C_cbXc9vc-9g", type: "fieldset" },
+  });
+
+  console.log("Destroy fields in existing models/block models");
+
+  console.log('Delete fieldset "Certificates" in model "Footer" (`footer`)');
+  await client.fieldsets.destroy("722063");
+
+  console.log(
+    'Delete Single asset field "Bcorp logo" (`bcorp_logo`) in model "Footer" (`footer`)',
+  );
+  await client.fields.destroy("9412470");
+
+  console.log(
+    'Delete Modular Content (Multiple blocks) field "B corp link" (`b_corp_links`) in model "Footer" (`footer`)',
+  );
+  await client.fields.destroy("9412471");
+
+  console.log(
+    'Delete Single asset field "Dutch digital agencies logo" (`dutch_digital_agencies_logo`) in model "Footer" (`footer`)',
+  );
+  await client.fields.destroy("9412472");
+
+  console.log(
+    'Delete Modular Content (Multiple blocks) field "Dutch digital agencies link" (`dutch_digital_agencies_links`) in model "Footer" (`footer`)',
+  );
+  await client.fields.destroy("9412473");
+
+  console.log(
+    'Delete Single asset field "ISO 27001 certification" (`iso27001certification`) in model "Footer" (`footer`)',
+  );
+  await client.fields.destroy("X9FELyPSTE20jpwSOrcxTA");
+
+  console.log(
+    'Delete Modular Content (Multiple blocks) field "ISO 27001 certification link" (`iso27001certification_link`) in model "Footer" (`footer`)',
+  );
+  await client.fields.destroy("I1Y_4gjeRdOdLpuK8LjubA");
+
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Modular Content (Multiple blocks) field "Certificates Grid" (`certificates_grid`) in model "Footer" (`footer`)',
+  );
+  await client.fields.update("F4MXL-00Sr-KfJn_gQAKYA", { position: 0 });
+
+  console.log('Update fieldset "Certificates" in model "Footer" (`footer`)');
+  await client.fieldsets.update("PvqIQFN4S1C_cbXc9vc-9g", { position: 7 });
+
+  console.log(
+    'Update Single-line string field "Copyright link" (`copyright_link`) in model "Footer" (`footer`)',
+  );
+  await client.fields.update("181847", { position: 6 });
+
+  console.log("Finalize models/block models");
+
+  console.log('Update block model "Menu Item" (`menu_item`)');
+  await client.itemTypes.update("F3_9OXD7SVmcNnbSpj1yGg", {
+    presentation_title_field: { id: "KiG_qn-oQ4CHhOpnzAhrwQ", type: "field" },
+    presentation_image_field: { id: "Wc-VzQQTQrqc7mWfzpkN1A", type: "field" },
+  });
+
+  console.log('Update model "Footer" (`footer`)');
+  await client.itemTypes.update("47595", {
+    presentation_image_field: null,
+    image_preview_field: null,
+  });
+}

--- a/src/components/app-footer/app-footer.vue
+++ b/src/components/app-footer/app-footer.vue
@@ -376,14 +376,14 @@ export default {
     gap: var(--spacing-small);
     margin-bottom: var(--spacing-large);
     padding-bottom: var(--spacing-large);
-    justify-content: space-between;
+    justify-content: center;
   }
 
   @media (min-width: 768px) {
     .app-footer__certificate-list {
       margin-bottom: var(--spacing-larger);
       padding-bottom: var(--spacing-larger);
-      justify-content: space-evenly;
+      gap: var(--spacing-larger);
     }
   }
 

--- a/src/components/app-footer/app-footer.vue
+++ b/src/components/app-footer/app-footer.vue
@@ -116,6 +116,7 @@
             :key="certificate.link.url"
           >
             <a
+              v-if="certificate.link?.__typename === 'ExternalLinkRecord'"
               :href="certificate.link.url"
               target="_blank"
               rel="noreferrer noopener"
@@ -130,6 +131,19 @@
                 loading="lazy"
               />
             </a>
+            <app-link
+              v-else
+              :to="useDatoNuxtRoute(certificate.link.link)"
+            >
+                <dato-image
+                class="app-footer__certificate-logo"
+                :src="certificate.image.url"
+                :width="100"
+                :height="75"
+                :alt="certificate.image.alt"
+                loading="lazy"
+              />
+            </app-link>
         </li>
       </ul>
     <div class="app-footer__bottom">

--- a/src/components/app-footer/app-footer.vue
+++ b/src/components/app-footer/app-footer.vue
@@ -107,32 +107,31 @@
             </a>
           </li>
         </ul>
-
-        <ul class="app-footer__certificate-list">
-          <li
-            v-for="certificate in certificateLinks"
-            :key="certificate.url"
+      </div>
+    </div>
+    <!-- CERTIFICATES GRID -->
+      <ul v-if="footer.certificatesGrid?.length" class="app-footer__certificate-list">
+        <li
+            v-for="certificate in footer.certificatesGrid"
+            :key="certificate.link.url"
           >
             <a
-              :href="certificate.url"
+              :href="certificate.link.url"
               target="_blank"
               rel="noreferrer noopener"
-              :aria-label="certificate.title"
+              :aria-label="certificate.link.title"
             >
               <dato-image
                 class="app-footer__certificate-logo"
-                :src="certificate.logo.url"
+                :src="certificate.image.url"
                 :width="100"
                 :height="75"
-                :alt="certificate.title"
+                :alt="certificate.image.alt"
                 loading="lazy"
               />
             </a>
-          </li>
-        </ul>
-      </div>
-    </div>
-
+        </li>
+      </ul>
     <div class="app-footer__bottom">
       <div class="body-detail app-footer__bottom-text">
         <dl class="app-footer__definition-list">
@@ -188,27 +187,6 @@ export default {
     }
   },
   computed: {
-    certificateLinks() {
-      const {
-        bCorpLinks,
-        bcorpLogo,
-        dutchDigitalAgenciesLinks,
-        dutchDigitalAgenciesLogo
-      } = this.footer
-
-      return [
-        {
-          url: bCorpLinks[0].url,
-          title: bCorpLinks[0].title,
-          logo: bcorpLogo
-        },
-        {
-          url: dutchDigitalAgenciesLinks[0].url,
-          title: dutchDigitalAgenciesLinks[0].title,
-          logo: dutchDigitalAgenciesLogo
-        }
-      ]
-    },
     socialLinks() {
       return [
         { url: this.app.githubUrl, platform: 'GitHub', icon: 'github' },
@@ -219,7 +197,7 @@ export default {
     },
     cleanedPhoneNumber() {
       return this.app.phoneNumber.replace(/[^0-9]/g, '')
-    }
+    },
   },
   mounted () {
     if ('IntersectionObserver' in window) {
@@ -250,7 +228,7 @@ export default {
     unobserveContact () {
       this.observer.unobserve(this.$refs.contact)
     }
-  },
+  }
 }
 </script>
 
@@ -392,20 +370,31 @@ export default {
 
   .app-footer__certificate-list {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
+    border-bottom: 1px solid var(--black);
     gap: var(--spacing-small);
+    margin-bottom: var(--spacing-large);
+    padding-bottom: var(--spacing-large);
+    justify-content: space-between;
   }
 
   @media (min-width: 768px) {
     .app-footer__certificate-list {
-      justify-content: space-between;
-      margin-top: var(--spacing-tiny);
+      margin-bottom: var(--spacing-larger);
+      padding-bottom: var(--spacing-larger);
+      justify-content: space-evenly;
     }
   }
 
   .app-footer__certificate-logo {
     width: 100%;
     object-fit: contain;
+    transition: opacity 0.3s ease;
+
+    &:hover {
+      opacity: 0.7;
+    }
   }
 
   .app-footer__list-address {

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'blog-post-scripts';
+export const datocmsEnvironment = 'footer-logo-block';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/layouts/content-page.query.graphql
+++ b/src/layouts/content-page.query.graphql
@@ -35,17 +35,8 @@ query DefaultLayout($locale: SiteLocale) {
     privacyTitle
     privacyLabel
     privacyLink
-    bCorpLinks {
-      ...externalLink
-    }
-    dutchDigitalAgenciesLinks {
-      ...externalLink
-    }
-    dutchDigitalAgenciesLogo {
-      ...image
-    }
-    bcorpLogo {
-      ...image
+    certificatesGrid {
+      ...menuItem
     }
   }
 }
@@ -96,4 +87,15 @@ fragment externalLink on ExternalLinkRecord {
     id
     title
     url
+}
+
+fragment menuItem on MenuItemRecord {
+  id
+  image {
+    ...image
+  }
+  link {
+    ...externalLink,
+    ...internalLink
+  }
 }

--- a/src/layouts/content-page.query.graphql
+++ b/src/layouts/content-page.query.graphql
@@ -84,6 +84,7 @@ fragment internalLink on InternalLinkRecord {
 }
 
 fragment externalLink on ExternalLinkRecord {
+    __typename
     id
     title
     url


### PR DESCRIPTION
## What changes were made

- Replaced the footer certificate mapping logic with rendering based on certificatesGrid.
- Updated the footer GraphQL query to fetch certificatesGrid instead of the previous dedicated certificate fields.
- Added a reusable menuItem fragment to support certificate image + link data (external or internal).
- Removed now-obsolete computed logic that assembled certificate links from separate fields.
- Adjusted footer certificate layout/styling

<img width="924" height="411" alt="image" src="https://github.com/user-attachments/assets/5c265c68-22ad-4f14-81d4-a90ea4d145f2" />

# Associated issue
#955
<!-- example:
Resolves #(ticket number)
-->

## How to test or check results
https://feat-footer-logo-block.voorhoede-website.pages.dev/en/
<!-- URL or instructions -->

## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
