### PR TITLE
fix: footer accessibility improvement

### DIFF
--- a/src/components/app-footer/app-footer.vue
+++ b/src/components/app-footer/app-footer.vue
@@ -348,6 +348,7 @@ export default {
 .app-footer__list {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  row-gap: var(--spacing-tiny);
   margin-bottom: var(--spacing-small);
 }
 
@@ -367,7 +368,7 @@ export default {
     flex-flow: column wrap;
     justify-content: flex-start;
     max-height: var(--footer-list-height);
-    gap: var(--spacing-tiny);
+    gap: var(--spacing-small);
     padding-bottom: 0;
   }
 }
@@ -438,7 +439,15 @@ export default {
   position: relative;
   z-index: var(--z-index-low);
   text-decoration: none;
-  padding: 6px 0;
+  padding-top: var(--spacing-tiny);
+}
+
+@media (min-width: 768px) {
+  .app-footer__link {
+    padding-block: 0;
+    padding-top: var(--spacing-smaller);
+    margin-top: calc(var(--spacing-smaller) * -1);
+  }
 }
 
 .app-footer__link:hover,

--- a/src/components/app-footer/app-footer.vue
+++ b/src/components/app-footer/app-footer.vue
@@ -3,6 +3,7 @@
     <div class="app-footer__layout">
       <div class="app-footer__header">
         <app-link
+          class="app-footer__header-link"
           :to="$localeUrl()"
           :aria-label="$t('home')"
           :title="$t('home')"
@@ -256,6 +257,11 @@ export default {
   margin-bottom: var(--spacing-large);
 }
 
+  .app-footer__header-link {
+    padding: var(--spacing-small) 0;
+    display: flex;
+  }
+
 @media (min-width: 768px) {
   .app-footer__layout {
     flex-direction: row;
@@ -361,7 +367,7 @@ export default {
     flex-flow: column wrap;
     justify-content: flex-start;
     max-height: var(--footer-list-height);
-    gap: var(--spacing-small);
+    gap: var(--spacing-tiny);
     padding-bottom: 0;
   }
 }
@@ -416,6 +422,7 @@ export default {
 
 .app-footer__list-item {
   text-decoration: none;
+    display: flex
 }
 
 .app-footer__list-item--icon {
@@ -431,6 +438,7 @@ export default {
   position: relative;
   z-index: var(--z-index-low);
   text-decoration: none;
+  padding: 6px 0;
 }
 
 .app-footer__link:hover,


### PR DESCRIPTION
## Changes

- Fixed an accessibility issue in the footer buttons.
<img width="824" height="721" alt="image" src="https://github.com/user-attachments/assets/cf797070-2e0a-4b4e-8d0a-ed7dd90482c4" />


## How to test

1. Open the [LINK](https://fix-accessibility-on-footer.voorhoede-website.pages.dev/en/)
2. Run Lighthouse:
   - Desktop accessibility score is 100%.
   - Mobile accessibility score is 100%.
6. Confirm no regressions in footer layout/interactions across viewport sizes.

## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
