### PR TITLE
add case list to page query

### DIFF
--- a/migrations/1779286315_addSectionCaseListBlock.ts
+++ b/migrations/1779286315_addSectionCaseListBlock.ts
@@ -1,0 +1,33 @@
+import type { Client } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Modular Content (Multiple blocks) field "Sections" (`sections`) in model "\uD83D\uDCD1 Page" (`page`)',
+  );
+  await client.fields.update("10461611", {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          "1466128",
+          "1471996",
+          "1514671",
+          "1517179",
+          "1646744",
+          "1757574",
+          "2037668",
+          "2037669",
+          "2037920",
+          "2037933",
+          "2037940",
+          "2040174",
+          "2040351",
+          "2040362",
+          "2486431",
+          "Y2qM8sXMR0-lwk-NZ0YZNg",
+        ],
+      },
+    },
+  });
+}

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'cleanup-models-deploy';
+export const datocmsEnvironment = 'section-case-list-block';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -248,6 +248,24 @@ query Page($locale: SiteLocale, $slug: String) {
           thumbnailUrl
         }
       }
+      ... on SectionCaseListRecord {
+        id
+        title
+        columns
+        cases {
+          title
+          slug
+          caseTeaser {
+            title
+            image {
+              url
+              alt
+              width
+              height
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/pages/[language]/[...slug]/index.vue
+++ b/src/pages/[language]/[...slug]/index.vue
@@ -114,6 +114,12 @@
         :mute="section.mute"
         :caption="section.caption"
       />
+      <cases-list
+        v-if="section.__typename === 'SectionCaseListRecord'"
+        :cases="section.cases"
+        :max-columns="section.columns"
+        :title="section.title"
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
## What changes were made
Make Section Case List accesible on PageQuery

## How to test or check results
Add Section Case List Block to a Page and see it render sucesfully.
https://1d1053df.voorhoede-website.pages.dev/en/cases-new/


## Checks
- [x] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [x] Appointed PR reviewers
