### PR TITLE
use customData of image in logo grid section

### DIFF
--- a/migrations/1779441955_addLogoUrlExplanation.ts
+++ b/migrations/1779441955_addLogoUrlExplanation.ts
@@ -1,0 +1,13 @@
+import type { Client } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Asset gallery field "Logos" (`logos`) in block model "\uD83C\uDFF7\uFE0F Section Logo Grid" (`section_logo_grid`)',
+  );
+  await client.fields.update("10482071", {
+    hint: "If you want turn the logo into a link, add a custom data field. <br>\n1st field should be: <strong>pageUrl</strong> <br>\n2nd field is the url; please note that the url format is NOT checked. You are responsible for this yourself\n",
+  });
+
+}

--- a/src/components/logo-grid/logo-grid.vue
+++ b/src/components/logo-grid/logo-grid.vue
@@ -5,7 +5,18 @@
     </h2>
     <ul class="logo-grid__list">
       <li class="logo-grid__item" v-for="(logo, index) in logos" :key="index">
+        <a v-if="logo.customData?.pageUrl" :href="logo.customData?.pageUrl" target="_blank" rel="noopener noreferrer">
+          <dato-image
+            class="logo-grid__image"
+            :src="logo.url"
+            :alt="logo.alt || ''"
+            :width="280"
+            :height="80"
+            loading="lazy"
+            />
+        </a>
         <dato-image
+          v-else
           class="logo-grid__image"
           :src="logo.url"
           :alt="logo.alt || ''"
@@ -24,6 +35,9 @@ defineProps<{
   logos: Array<{
     url: string;
     alt: string;
+    customData?: {
+      pageUrl?: string;
+    };
   }>;
 }>();
 </script>

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'section-case-list-block';
+export const datocmsEnvironment = 'add-logo-link';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -79,6 +79,7 @@ query Page($locale: SiteLocale, $slug: String) {
         title
         logos {
           ...image
+          customData
         }
       }
       ... on SectionDialogueCtaRecord {

--- a/src/pages/[language]/index.query.graphql
+++ b/src/pages/[language]/index.query.graphql
@@ -41,6 +41,7 @@ query HomePage($locale: SiteLocale!) {
         title
         logos {
           ...image
+          customData
         }
       }
       ... on SectionDialogueCtaRecord {
@@ -88,6 +89,7 @@ query HomePage($locale: SiteLocale!) {
                 title
                 logos {
                   ...image
+                  customData
                 }
               }
             }


### PR DESCRIPTION
## What changes were made
- access [customData](https://www.datocms.com/docs/general-concepts/media-area#localization) property of imageField if available
- add message to LogoGridSection to instruct usage

**Note**
This solution is a bit hacky and content editors need to be aware of this function. Since this is our own website and we have tech-savvy people, me and the marketing team decided on this. Mostly to keep the below layout in the Dato UI; this is only possible for images.

<img width="1091" height="812" alt="Screenshot 2026-05-22 at 13 55 33" src="https://github.com/user-attachments/assets/a7848480-d15c-485b-844e-d9b2b8182a29" />

## How to test or check results

<!-- URL or instructions -->

## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [ ] Appointed PR reviewers
