### PR TITLE
Fix/minor UI

### DIFF
--- a/migrations/1779974972_addImageTypesSectionTextImage.ts
+++ b/migrations/1779974972_addImageTypesSectionTextImage.ts
@@ -1,0 +1,16 @@
+import { Client } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Single asset field "Image" (`image`) in block model "Section Image & Text" (`section_image_text`)',
+  );
+  await client.fields.update("10461620", {
+    validators: {
+      required: {},
+      extension: { extensions: [], predefined_list: "image" },
+      required_alt_title: { title: false, alt: true },
+    },
+  });
+}

--- a/migrations/1779978869_addCTAToPages.ts
+++ b/migrations/1779978869_addCTAToPages.ts
@@ -1,0 +1,89 @@
+import { Client } from "@datocms/cli/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Update existing fields/fieldsets");
+
+  console.log(
+    'Update Modular Content (Multiple blocks) field "Sections" (`sections`) in model "\uD83D\uDCD1 Page" (`page`)',
+  );
+  await client.fields.update("10461611", {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          "262363",
+          "1466128",
+          "1471996",
+          "1514671",
+          "1517179",
+          "1646744",
+          "1757574",
+          "2037668",
+          "2037669",
+          "2037920",
+          "2037933",
+          "2037940",
+          "2040174",
+          "2040351",
+          "2040362",
+          "2486431",
+          "AjYd96IgQYuBzefFaL5VBA",
+          "G8-kViMTTG62MbHNzPc7PQ",
+          "Y2qM8sXMR0-lwk-NZ0YZNg",
+        ],
+      },
+    },
+  });
+
+  console.log(
+    'Update Modular Content (Multiple blocks) field "Sections" (`sections`) in model "\uD83C\uDFE0 Home" (`home_page`)',
+  );
+  await client.fields.update("Y66TEEOYTDuIltz0RySVEA", {
+    validators: {
+      rich_text_blocks: {
+        item_types: [
+          "262363",
+          "1757574",
+          "2037668",
+          "2040174",
+          "2040362",
+          "2486431",
+          "AjYd96IgQYuBzefFaL5VBA",
+          "CL2tcnR9TimpzQxNR2RKCg",
+          "CrAZK2ukS-Cev0D-CSbA2g",
+          "G8-kViMTTG62MbHNzPc7PQ",
+        ],
+      },
+    },
+  });
+
+  console.log(
+    'Update Modular Content (Single block) field "Section" (`section`) in model "\uD83D\uDCC4 Page Partial" (`page_partial`)',
+  );
+  await client.fields.update("YitgdnMGTpuQkl6GFYkGLQ", {
+    validators: {
+      single_block_blocks: {
+        item_types: [
+          "262363",
+          "1466128",
+          "1471996",
+          "1514671",
+          "1517179",
+          "1646744",
+          "1757574",
+          "2037668",
+          "2037669",
+          "2037920",
+          "2037933",
+          "2037940",
+          "2040174",
+          "2040351",
+          "2040362",
+          "2486431",
+          "CL2tcnR9TimpzQxNR2RKCg",
+          "CrAZK2ukS-Cev0D-CSbA2g",
+          "Y2qM8sXMR0-lwk-NZ0YZNg",
+        ],
+      },
+    },
+  });
+}

--- a/src/components/cta-block/cta-block.vue
+++ b/src/components/cta-block/cta-block.vue
@@ -1,4 +1,5 @@
 <template>
+  <div class="cta-block">
   <cta-image-block
     v-if="Boolean(item.person)"
     :key="item.id"
@@ -22,6 +23,7 @@
     :link-label="item.linkLabel"
     :link-url="item.linkUrl"
   />
+  </div>
 </template>
 
 <script>
@@ -35,3 +37,15 @@
     }
   }
 </script>
+
+<style>
+.cta-block {
+  margin-left: var(--spacing-small);
+  margin-right: var(--spacing-small);
+}
+@media (min-width: 768px) {
+  .cta-block {
+    width: fit-content;
+  }
+}
+</style>

--- a/src/components/cta-image-block/cta-image-block.vue
+++ b/src/components/cta-image-block/cta-image-block.vue
@@ -127,6 +127,8 @@
     .cta-image-block__ctas {
       display: flex;
       align-items: center;
+      align-content: flex-start;
+      flex-direction: column;
       flex-wrap: wrap;
     }
   }

--- a/src/components/dato-image/dato-image.vue
+++ b/src/components/dato-image/dato-image.vue
@@ -1,9 +1,20 @@
 <template>
+  <img
+    v-if="isSvg"
+    class="dato-image"
+    :src="props.src"
+    :alt="props.alt"
+    :width="props.width"
+    :height="props.height"
+    :loading="props.loading"
+    decoding="async"
+  >
   <Image
+    v-else
     class="dato-image"
     v-bind="props"
-    :loader="loader"
-    :srcset="checkedSrcset"
+    :loader="imgixLoader"
+    :srcset="props.srcset"
   />
 </template>
 
@@ -16,6 +27,8 @@ const props = defineProps<Omit<ImageProps, 'loader'> & {
   modifiers?: ImgixUrl.Params;
 }>();
 
+const isSvg = computed(() => props.src.endsWith('.svg'));
+
 const imgixLoader: ImageLoader = ({ src, width, quality }) =>
   withQuery(src, {
     w: width,
@@ -24,14 +37,6 @@ const imgixLoader: ImageLoader = ({ src, width, quality }) =>
     cs: "origin",
     ...(props.modifiers as QueryObject),
   });
-
-const loader = computed(() =>
-  props.src.endsWith(".svg") ? ({ src }: { src: string }) => src : imgixLoader
-);
-
-const checkedSrcset = computed(() =>
-  props.src.endsWith(".svg") ? "" : props.srcset
-);
 </script>
 
 <style>

--- a/src/components/image-with-text-block/image-with-text-block.vue
+++ b/src/components/image-with-text-block/image-with-text-block.vue
@@ -9,7 +9,7 @@
     <dato-image
       class="image-with-text__image"
       :src="image.url"
-      alt=""
+      alt="image.alt"
       :width="image.width"
       :height="image.height"
       sizes="(min-width: 1100px) 730px, (min-width: 720px) 40vw, 90vw"

--- a/src/components/page-partial-block/page-partial-block.vue
+++ b/src/components/page-partial-block/page-partial-block.vue
@@ -125,6 +125,17 @@
     :layout="item.section.layout"
     :image="item.section.image"
   />
+  <cta-block
+    v-if="item.section.__typename === 'CallToActionRecord'"
+    :id="item.section.id"
+    :body="item.section.body"
+    :title="item.section.title"
+    :item="item.section"
+    :person="item.section.person"
+    :secondary-link-label="item.section.secondaryLinkLabel"
+    :secondary-link-url="item.section.secondaryLinkUrl"
+    :secondary-link-is-external="item.section.secondaryLinkIsExternal"
+  />
 </template>
 
 <script setup lang="ts">

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,2 +1,2 @@
-export const datocmsEnvironment = 'add-page-partial';
+export const datocmsEnvironment = 'fix-minor-ui';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';

--- a/src/pages/[language]/[...slug]/index.query.graphql
+++ b/src/pages/[language]/[...slug]/index.query.graphql
@@ -582,7 +582,41 @@ query Page($locale: SiteLocale, $slug: String) {
                 }
               }
             }
+            ... on CallToActionRecord {
+              id
+              title
+              body
+              linkLabel
+              linkUrl
+              linkIsExternal
+              secondaryLinkLabel
+              secondaryLinkUrl
+              secondaryLinkIsExternal
+              person {
+                image {
+                  ...image
+                }
+                name
+              }
+            }
           }
+        }
+      }
+      ... on CallToActionRecord {
+        id
+        title
+        body
+        linkLabel
+        linkUrl
+        linkIsExternal
+        secondaryLinkLabel
+        secondaryLinkUrl
+        secondaryLinkIsExternal
+        person {
+          image {
+            ...image
+          }
+          name
         }
       }
     }

--- a/src/pages/[language]/[...slug]/index.vue
+++ b/src/pages/[language]/[...slug]/index.vue
@@ -212,4 +212,15 @@
   .landing-page__section:not(.landing-page__section--background) + .landing-page__section--background {
     margin-top: var(--spacing-big);
   }
+
+  .landing-page__section--pastel-background + .landing-page__section--pastel-background:not(:has(.grouping-block)),
+  .landing-page__section--grey-background + .landing-page__section--grey-background:not(:has(.grouping-block)) {
+    padding-top: var(--spacing-large);
+  }
+
+  .landing-page__section--pastel-background:has(+ .landing-page__section--pastel-background),
+  .landing-page__section--grey-background:has(+ .landing-page__section--grey-background) {
+    padding-bottom: var(--spacing-large);
+  }
+
 </style>

--- a/src/pages/[language]/[...slug]/index.vue
+++ b/src/pages/[language]/[...slug]/index.vue
@@ -128,6 +128,15 @@
         v-if="section.__typename === 'SectionGlossaryRecord'"
         :title="section.title"
       />
+      <cta-block
+        v-if="section.__typename === 'CallToActionRecord'"
+        :key="section.id"
+        :id="section.id"
+        :body="section.body"
+        :title="section.title"
+        :item="section"
+        :person="section.person"
+      />
     </div>
   </div>
 </template>

--- a/src/pages/[language]/index.query.graphql
+++ b/src/pages/[language]/index.query.graphql
@@ -123,6 +123,23 @@ query HomePage($locale: SiteLocale!) {
           }
         }
       }
+      ... on CallToActionRecord {
+        id
+        title
+        body
+        linkLabel
+        linkUrl
+        linkIsExternal
+        secondaryLinkLabel
+        secondaryLinkUrl
+        secondaryLinkIsExternal
+        person {
+          image {
+            ...image
+          }
+          name
+        }
+      }
       ... on PagePartialBlockRecord {
         id
         item {
@@ -416,6 +433,23 @@ query HomePage($locale: SiteLocale!) {
                     }
                   }
                 }
+              }
+            }
+            ... on CallToActionRecord {
+              id
+              title
+              body
+              linkLabel
+              linkUrl
+              linkIsExternal
+              secondaryLinkLabel
+              secondaryLinkUrl
+              secondaryLinkIsExternal
+              person {
+                image {
+                  ...image
+                }
+                name
               }
             }
           }

--- a/src/pages/[language]/index.vue
+++ b/src/pages/[language]/index.vue
@@ -14,6 +14,15 @@
         :theme="section.theme"
         :accent-position="section.accentPosition"
       />
+      <cta-block
+        v-if="section.__typename === 'CallToActionRecord'"
+        :key="section.id"
+        :id="section.id"
+        :body="section.body"
+        :title="section.title"
+        :item="section"
+        :person="section.person"
+      />
       <page-partial-block
         v-if="section.__typename === 'PagePartialBlockRecord'"
         :item="section.item"


### PR DESCRIPTION
## What changes were made
- support SVG images for Section Text Image Block (only block that didn't untill so far, I found no specific reason for this)
- add CTA block to PageRecord, HomeRecord and PagePartial
- add separate spacing rule for same colored blocks so it looks better.

## How to test or check results
- 'cases-new' Page can use a CTA block
- HomePage can use a CTA block
- 'cases-new' Page can use a CTA block inside Page Partial
- HomePage can use a CTA block inside Page Partial
- Section Text Image Block can use a svg
- 'cases-new' Page looks good, no off spacing.
- other PageRecords look good, no off spacing.


## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [ ] Appointed PR reviewers
