### PR TITLE
feat: page partial block

### DIFF
--- a/src/components/Blocks/Blocks.vue
+++ b/src/components/Blocks/Blocks.vue
@@ -9,6 +9,8 @@ import type { LogoGridFragment } from "./LogoGrid/LogoGrid.query";
 import LogoGrid from "./LogoGrid/LogoGrid.vue";
 import type { PageHeaderFragment } from "./PageHeader/PageHeader.query";
 import PageHeader from "./PageHeader/PageHeader.vue";
+import type { PagePartialFragment } from "./PagePartial/PagePartial.query";
+import PagePartial from "./PagePartial/PagePartial.vue";
 import type { TextImageFragment } from "./TextImage/TextImage.query";
 import TextImage from "./TextImage/TextImage.vue";
 
@@ -28,6 +30,9 @@ const props = defineProps<{
       })
     | (FragmentOf<typeof PageHeaderFragment> & {
         __typename: "SectionHeaderRecord";
+      })
+    | (FragmentOf<typeof PagePartialFragment> & {
+        __typename: "PagePartialBlockRecord";
       })
     | (FragmentOf<typeof TextImageFragment> & {
         __typename: "SectionTextImageRecord";
@@ -56,6 +61,10 @@ const props = defineProps<{
     />
     <PageHeader
       v-else-if="block?.__typename === 'SectionHeaderRecord'"
+      :data="block"
+    />
+    <PagePartial
+      v-else-if="block?.__typename === 'PagePartialBlockRecord'"
       :data="block"
     />
     <TextImage

--- a/src/components/Blocks/Blocks.vue
+++ b/src/components/Blocks/Blocks.vue
@@ -1,43 +1,15 @@
 <script setup lang="ts">
-import type { CaseListFragment } from "./CaseList/CaseList.query";
+import type { BlockItem } from "./PagePartial/types";
 import CaseList from "./CaseList/CaseList.vue";
-import type { DialogueCtaFragment } from "./DialogueCta/DialogueCta.query";
 import DialogueCta from "./DialogueCta/DialogueCta.vue";
-import type { ImageCardGridFragment } from "./ImageCardGrid/ImageCardGrid.query";
 import ImageCardGrid from "./ImageCardGrid/ImageCardGrid.vue";
-import type { LogoGridFragment } from "./LogoGrid/LogoGrid.query";
 import LogoGrid from "./LogoGrid/LogoGrid.vue";
-import type { PageHeaderFragment } from "./PageHeader/PageHeader.query";
 import PageHeader from "./PageHeader/PageHeader.vue";
-import type { PagePartialFragment } from "./PagePartial/PagePartial.query";
 import PagePartial from "./PagePartial/PagePartial.vue";
-import type { TextImageFragment } from "./TextImage/TextImage.query";
 import TextImage from "./TextImage/TextImage.vue";
 
 const props = defineProps<{
-  blocks: Array<
-    | (FragmentOf<typeof CaseListFragment> & {
-        __typename: "SectionCaseListRecord";
-      })
-    | (FragmentOf<typeof DialogueCtaFragment> & {
-        __typename: "SectionDialogueCtaRecord";
-      })
-    | (FragmentOf<typeof ImageCardGridFragment> & {
-        __typename: "SectionImageCardGridRecord";
-      })
-    | (FragmentOf<typeof LogoGridFragment> & {
-        __typename: "SectionLogoGridRecord";
-      })
-    | (FragmentOf<typeof PageHeaderFragment> & {
-        __typename: "SectionHeaderRecord";
-      })
-    | (FragmentOf<typeof PagePartialFragment> & {
-        __typename: "PagePartialBlockRecord";
-      })
-    | (FragmentOf<typeof TextImageFragment> & {
-        __typename: "SectionTextImageRecord";
-      })
-  >;
+  blocks: BlockItem[];
 }>();
 </script>
 

--- a/src/components/Blocks/PagePartial/PagePartial.query.ts
+++ b/src/components/Blocks/PagePartial/PagePartial.query.ts
@@ -1,7 +1,10 @@
 import { graphql } from "~/utils/graphql";
 import { CaseListFragment } from "../CaseList/CaseList.query";
 import { DialogueCtaFragment } from "../DialogueCta/DialogueCta.query";
+import { ImageCardGridFragment } from "../ImageCardGrid/ImageCardGrid.query";
 import { LogoGridFragment } from "../LogoGrid/LogoGrid.query";
+import { PageHeaderFragment } from "../PageHeader/PageHeader.query";
+import { TextImageFragment } from "../TextImage/TextImage.query";
 
 export const PagePartialFragment = graphql(
   `fragment PagePartialFragment on PagePartialBlockRecord {
@@ -14,9 +17,19 @@ export const PagePartialFragment = graphql(
           __typename
           ...CaseListFragment
           ...DialogueCtaFragment
+          ...ImageCardGridFragment
           ...LogoGridFragment
+          ...PageHeaderFragment
+          ...TextImageFragment
         }
       }
     }`,
-  [CaseListFragment, DialogueCtaFragment, LogoGridFragment],
+  [
+    CaseListFragment,
+    DialogueCtaFragment,
+    ImageCardGridFragment,
+    LogoGridFragment,
+    PageHeaderFragment,
+    TextImageFragment,
+  ],
 );

--- a/src/components/Blocks/PagePartial/PagePartial.query.ts
+++ b/src/components/Blocks/PagePartial/PagePartial.query.ts
@@ -1,0 +1,22 @@
+import { graphql } from "~/utils/graphql";
+import { CaseListFragment } from "../CaseList/CaseList.query";
+import { DialogueCtaFragment } from "../DialogueCta/DialogueCta.query";
+import { LogoGridFragment } from "../LogoGrid/LogoGrid.query";
+
+export const PagePartialFragment = graphql(
+  `fragment PagePartialFragment on PagePartialBlockRecord {
+      __typename
+      id
+      item {
+        id
+        title
+        section {
+          __typename
+          ...CaseListFragment
+          ...DialogueCtaFragment
+          ...LogoGridFragment
+        }
+      }
+    }`,
+  [CaseListFragment, DialogueCtaFragment, LogoGridFragment],
+);

--- a/src/components/Blocks/PagePartial/PagePartial.vue
+++ b/src/components/Blocks/PagePartial/PagePartial.vue
@@ -1,0 +1,23 @@
+<template>
+  <Blocks v-if="section" :blocks="[section]" />
+</template>
+
+<script setup lang="ts">
+import { type PagePartialFragment } from "./PagePartial.query";
+import { type FragmentOf, readFragment } from "~/utils/graphql";
+import Blocks from "../Blocks.vue";
+
+const props = defineProps<{
+  data: FragmentOf<typeof PagePartialFragment>;
+}>();
+
+const data = readFragment<typeof PagePartialFragment>(props.data);
+
+// `section` is a single masked block. Its field type is the full section union,
+// so gql.tada widens the members the fragment doesn't select to `{ __typename }`
+// only; cast to the block type `Blocks` accepts (CaseList/DialogueCta/LogoGrid
+// are the members actually spread, so this is sound at runtime).
+type BlockItem = InstanceType<typeof Blocks>["$props"]["blocks"][number];
+
+const section = computed(() => data.item?.section as BlockItem | undefined);
+</script>

--- a/src/components/Blocks/PagePartial/PagePartial.vue
+++ b/src/components/Blocks/PagePartial/PagePartial.vue
@@ -5,7 +5,7 @@
 <script setup lang="ts">
 import { type PagePartialFragment } from "./PagePartial.query";
 import { type FragmentOf, readFragment } from "~/utils/graphql";
-import Blocks from "../Blocks.vue";
+import type { BlockItem } from "./types";
 
 const props = defineProps<{
   data: FragmentOf<typeof PagePartialFragment>;
@@ -13,11 +13,10 @@ const props = defineProps<{
 
 const data = readFragment<typeof PagePartialFragment>(props.data);
 
-// `section` is a single masked block. Its field type is the full section union,
-// so gql.tada widens the members the fragment doesn't select to `{ __typename }`
-// only; cast to the block type `Blocks` accepts (CaseList/DialogueCta/LogoGrid
-// are the members actually spread, so this is sound at runtime).
-type BlockItem = InstanceType<typeof Blocks>["$props"]["blocks"][number];
+type SupportedBlockItem = Exclude<
+  BlockItem,
+  { __typename: "PagePartialBlockRecord" }
+>;
 
-const section = computed(() => data.item?.section as BlockItem | undefined);
+const section = computed(() => data.item?.section as SupportedBlockItem);
 </script>

--- a/src/components/Blocks/PagePartial/types.ts
+++ b/src/components/Blocks/PagePartial/types.ts
@@ -1,0 +1,30 @@
+import type { CaseListFragment } from "../CaseList/CaseList.query";
+import type { DialogueCtaFragment } from "../DialogueCta/DialogueCta.query";
+import type { ImageCardGridFragment } from "../ImageCardGrid/ImageCardGrid.query";
+import type { LogoGridFragment } from "../LogoGrid/LogoGrid.query";
+import type { PageHeaderFragment } from "../PageHeader/PageHeader.query";
+import type { PagePartialFragment } from "../PagePartial/PagePartial.query";
+import type { TextImageFragment } from "../TextImage/TextImage.query";
+
+export type BlockItem =
+  | (FragmentOf<typeof CaseListFragment> & {
+      __typename: "SectionCaseListRecord";
+    })
+  | (FragmentOf<typeof DialogueCtaFragment> & {
+      __typename: "SectionDialogueCtaRecord";
+    })
+  | (FragmentOf<typeof ImageCardGridFragment> & {
+      __typename: "SectionImageCardGridRecord";
+    })
+  | (FragmentOf<typeof LogoGridFragment> & {
+      __typename: "SectionLogoGridRecord";
+    })
+  | (FragmentOf<typeof PageHeaderFragment> & {
+      __typename: "SectionHeaderRecord";
+    })
+  | (FragmentOf<typeof PagePartialFragment> & {
+      __typename: "PagePartialBlockRecord";
+    })
+  | (FragmentOf<typeof TextImageFragment> & {
+      __typename: "SectionTextImageRecord";
+    });

--- a/src/pages/[language]/index.vue
+++ b/src/pages/[language]/index.vue
@@ -45,6 +45,7 @@ import { DialogueCtaFragment } from "~/components/Blocks/DialogueCta/DialogueCta
 import { ImageCardGridFragment } from "~/components/Blocks/ImageCardGrid/ImageCardGrid.query";
 import { LogoGridFragment } from "~/components/Blocks/LogoGrid/LogoGrid.query";
 import { PageHeaderFragment } from "~/components/Blocks/PageHeader/PageHeader.query";
+import { PagePartialFragment } from "~/components/Blocks/PagePartial/PagePartial.query";
 import { TextImageFragment } from "~/components/Blocks/TextImage/TextImage.query";
 
 const route = useRoute();
@@ -70,6 +71,7 @@ const query = graphql(
           ...ImageCardGridFragment
           ...LogoGridFragment
           ...PageHeaderFragment
+          ...PagePartialFragment
           ...TextImageFragment
         }
       }
@@ -101,6 +103,7 @@ const query = graphql(
     ImageCardGridFragment,
     LogoGridFragment,
     PageHeaderFragment,
+    PagePartialFragment,
     TextImageFragment,
   ],
 );


### PR DESCRIPTION
Adds support for the **page partial** block and renders it (and its nested section) on the home page.

### What's included
- **`PagePartial.query.ts`** — gql.tada fragment for `PagePartialBlockRecord`. Spreads all six migrated block fragments for the partial's nested `section`: CaseList, DialogueCta, ImageCardGrid, LogoGrid, PageHeader, TextImage.
- **`PagePartial.vue`** — unwraps the record's nested `section` and renders it through the existing `Blocks` component.
- **`Blocks.vue`** — adds `PagePartialBlockRecord` to the dispatcher (prop union + render branch) so page partials render wherever `Blocks` is used.
- **`index.vue`** (home page) — wires `PagePartialFragment` into the `HomePage` query so the block's data is fetched.

### Notes for reviewers
- The partial supports the 6 currently-migrated section types; the remaining `PagePartialModelSectionField` members can be added as their fragments are migrated.
