### PR TITLE
Add rehype-remove-empty-elements plugin to remove empty elements from HTML

### DIFF
--- a/src/lib/rehype/rehype-remove-empty-elements.ts
+++ b/src/lib/rehype/rehype-remove-empty-elements.ts
@@ -1,0 +1,30 @@
+import type { Element, Root } from 'hast';
+import type { Plugin } from 'unified';
+
+/**
+ * Tags that produce Markdown without text, so they keep their ancestors alive
+ * (`<a>` around an `<img>` isn't empty). `<svg>` is excluded, icons render to
+ * nothing, so a link wrapping only an icon is empty.
+ */
+const selfMeaningfulTags = new Set(['img', 'hr', 'br']);
+
+function hasMeaningfulContent(node: Element | Root): boolean {
+  return node.children.some((child) => {
+    if (child.type === 'text') return child.value.trim() !== '';
+    if (child.type !== 'element') return false;
+    return selfMeaningfulTags.has(child.tagName) || hasMeaningfulContent(child);
+  });
+}
+
+// Bottom-up, so an element emptied by pruning its children is dropped too.
+function removeEmptyElements(node: Element | Root) {
+  node.children = node.children.filter((child) => {
+    if (child.type !== 'element') return true;
+    removeEmptyElements(child);
+    return selfMeaningfulTags.has(child.tagName) || hasMeaningfulContent(child);
+  });
+}
+
+export const rehypeRemoveEmptyElements: Plugin<[], Root> = () => (tree) => {
+  removeEmptyElements(tree);
+};

--- a/src/scripts/html-to-markdown.ts
+++ b/src/scripts/html-to-markdown.ts
@@ -3,11 +3,12 @@ import rehypeRemark from 'rehype-remark';
 import remarkGfm from 'remark-gfm';
 import remarkStringify from 'remark-stringify';
 import { unified } from 'unified';
+import { buildFrontmatter } from '../lib/frontmatter.js';
 import { rehypeExtractContent } from '../lib/rehype/rehype-extract-content.js';
 import { rehypeExtractMeta, type PageMeta } from '../lib/rehype/rehype-extract-meta.js';
+import { rehypeRemoveEmptyElements } from '../lib/rehype/rehype-remove-empty-elements.js';
 import { rehypeRewriteLinksToMarkdown } from '../lib/rehype/rehype-rewrite-links-to-markdown.js';
 import { rehypeStripComments } from '../lib/rehype/rehype-strip-comments.js';
-import { buildFrontmatter } from '../lib/frontmatter.js';
 
 interface HtmlToMarkdownOptions {
   html: string;
@@ -23,12 +24,14 @@ function buildProcessor(origin: string) {
       selector: '#content',
       exclude: [
         '.app-footer',
+        '.open-in-llm',
         '[aria-hidden="true"]',
         'img:not([alt])',
         'img[alt=""]',
       ],
     })
     .use(rehypeStripComments)
+    .use(rehypeRemoveEmptyElements)
     .use(rehypeRewriteLinksToMarkdown, { origin })
     .use(rehypeRemark)
     .use(remarkGfm)


### PR DESCRIPTION
## What changes were made

Fixes the 2 issues reported by Jasper, removing empty links and other elements from the MD (mainly caused by the fact that I exclude images without an alt which lead to empty links in the md). And exclude the `open-in-llm` component from the md.

## How to test or check results

Before:
```
Blog

# How to select a framework for design system components

[](/en/team/jasper.md)

By [Jasper](/en/team/jasper.md)

12 December 2022

Copy page▾

* [Open as Markdown](/en/blog/how-to-select-framework-design-system-components.md)
* [Open in Claude](https://claude.ai/new?q=Read%20https%3A%2F%2Fwww.voorhoede.nl%2Fen%2Fblog%2Fhow-to-select-framework-design-system-components.md%20so%20I%20can%20ask%20questions%20about%20its%20contents.)
* [Open in ChatGPT](https://chatgpt.com/?q=Read%20https%3A%2F%2Fwww.voorhoede.nl%2Fen%2Fblog%2Fhow-to-select-framework-design-system-components.md%20so%20I%20can%20ask%20questions%20about%20its%20contents.\&hints=search)

- [](https://www.linkedin.com/shareArticle?\&url=https://www.voorhoede.nl/en/blog/how-to-select-framework-design-system-components/\&title=)
```

After:
```

Blog

# How to select a framework for design system components

By [Jasper](/en/team/jasper.md)

12 December 2022
```

<!-- URL or instructions -->

## Checks
- [X] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [X] Appointed PR reviewers
