### PR TITLE
Add structured text with link blocks to CaseList and ImageCardGrid

### DIFF
--- a/migrations/1781870329_addCardsCasesLinks.ts
+++ b/migrations/1781870329_addCardsCasesLinks.ts
@@ -1,0 +1,103 @@
+import type { Client} from "datocms/lib/cma-client-node";
+
+export default async function (client: Client) {
+  console.log("Creating new fields/fieldsets");
+
+  console.log(
+    'Create Structured text field "Text" (`text`) in block model "Section Image Card Grid" (`section_image_card_grid`)',
+  );
+  await client.fields.create("1757574", {
+    id: "ZQa4n-GXSHysd0KepXvkNQ",
+    label: "Text",
+    field_type: "structured_text",
+    api_key: "text",
+    validators: {
+      structured_text_blocks: { item_types: ["2034503", "2037919"] },
+      structured_text_inline_blocks: { item_types: [] },
+      structured_text_links: {
+        on_publish_with_unpublished_references_strategy: "fail",
+        on_reference_unpublish_strategy: "delete_references",
+        on_reference_delete_strategy: "delete_references",
+        item_types: [],
+      },
+    },
+    appearance: {
+      addons: [],
+      editor: "structured_text",
+      parameters: {
+        marks: [
+          "strong",
+          "code",
+          "emphasis",
+          "underline",
+          "strikethrough",
+          "highlight",
+        ],
+        nodes: [
+          "blockquote",
+          "code",
+          "heading",
+          "inlineItem",
+          "itemLink",
+          "link",
+          "list",
+          "thematicBreak",
+        ],
+        heading_levels: [1, 2, 3, 4, 5, 6],
+        blocks_start_collapsed: false,
+        show_links_meta_editor: false,
+        show_links_target_blank: true,
+      },
+    },
+    default_value: null,
+  });
+
+  console.log(
+    'Create Structured text field "Text" (`text`) in block model "\uD83D\uDCBC Section Case List" (`section_case_list`)',
+  );
+  await client.fields.create("2486431", {
+    id: "RkmmaYGcQ8WhFyHB0aCFSQ",
+    label: "Text",
+    field_type: "structured_text",
+    api_key: "text",
+    validators: {
+      structured_text_blocks: { item_types: ["2034503", "2037919"] },
+      structured_text_inline_blocks: { item_types: [] },
+      structured_text_links: {
+        on_publish_with_unpublished_references_strategy: "fail",
+        on_reference_unpublish_strategy: "delete_references",
+        on_reference_delete_strategy: "delete_references",
+        item_types: [],
+      },
+    },
+    appearance: {
+      addons: [],
+      editor: "structured_text",
+      parameters: {
+        marks: [
+          "strong",
+          "code",
+          "emphasis",
+          "underline",
+          "strikethrough",
+          "highlight",
+        ],
+        nodes: [
+          "blockquote",
+          "code",
+          "heading",
+          "inlineItem",
+          "itemLink",
+          "link",
+          "list",
+          "thematicBreak",
+        ],
+        heading_levels: [1, 2, 3, 4, 5, 6],
+        blocks_start_collapsed: false,
+        show_links_meta_editor: false,
+        show_links_target_blank: true,
+      },
+    },
+    default_value: null,
+  });
+}

--- a/shared/generated/schema.graphql
+++ b/shared/generated/schema.graphql
@@ -3992,15 +3992,19 @@ type GroupingItemRecord implements RecordInterface {
 """Linking fields"""
 enum HomePageModelFieldsReferencingBlogPostModel {
   homePage_sections
+  homePage_sections__sectionCaseList_text__internalLink_link
   homePage_sections__sectionDialogueCta_ctas__internalLink_link
   homePage_sections__sectionImageCardGrid_items__sectionImageCardGridItem_links__internalLink_link
+  homePage_sections__sectionImageCardGrid_text__internalLink_link
 }
 
 """Linking fields"""
 enum HomePageModelFieldsReferencingMeetModel {
   homePage_sections
+  homePage_sections__sectionCaseList_text__internalLink_link
   homePage_sections__sectionDialogueCta_ctas__internalLink_link
   homePage_sections__sectionImageCardGrid_items__sectionImageCardGridItem_links__internalLink_link
+  homePage_sections__sectionImageCardGrid_text__internalLink_link
 }
 
 input HomePageModelFilter {
@@ -8191,10 +8195,29 @@ type MenuRecord implements RecordInterface {
 
 scalar MetaTagAttributes
 
+enum MuxThumbnailFitMode {
+  preserve
+  stretch
+  crop
+  smartcrop
+  pad
+}
+
 enum MuxThumbnailFormatType {
   jpg
   png
   gif
+}
+
+enum MuxThumbnailRotation {
+  """Rotate 90° clockwise"""
+  ROTATE_90
+
+  """Rotate 180° clockwise"""
+  ROTATE_180
+
+  """Rotate 270° clockwise"""
+  ROTATE_270
 }
 
 input OpenGraphImageModelFilter {
@@ -8316,8 +8339,10 @@ enum PageModelFieldsReferencingBlogPostModel {
   page_sections
   page_sections__sectionBlogsSection_items
   page_sections__sectionBlogsSection_pinnedItems
+  page_sections__sectionCaseList_text__internalLink_link
   page_sections__sectionDialogueCta_ctas__internalLink_link
   page_sections__sectionImageCardGrid_items__sectionImageCardGridItem_links__internalLink_link
+  page_sections__sectionImageCardGrid_text__internalLink_link
   page_sections__sectionImageText_body__structuredTextBlueText_body__structuredTextButtonsList_buttons__internalLink_link
   page_sections__sectionImageText_body__structuredTextButtonsList_buttons__internalLink_link
   page_sections__sectionInterstitialCta_ctas__internalLink_link
@@ -8330,8 +8355,10 @@ enum PageModelFieldsReferencingBlogPostModel {
 """Linking fields"""
 enum PageModelFieldsReferencingMeetModel {
   page_sections
+  page_sections__sectionCaseList_text__internalLink_link
   page_sections__sectionDialogueCta_ctas__internalLink_link
   page_sections__sectionImageCardGrid_items__sectionImageCardGridItem_links__internalLink_link
+  page_sections__sectionImageCardGrid_text__internalLink_link
   page_sections__sectionImageText_body__structuredTextBlueText_body__structuredTextButtonsList_buttons__internalLink_link
   page_sections__sectionImageText_body__structuredTextButtonsList_buttons__internalLink_link
   page_sections__sectionInterstitialCta_ctas__internalLink_link
@@ -8426,8 +8453,10 @@ enum PagePartialModelFieldsReferencingBlogPostModel {
   pagePartial_section
   pagePartial_section__sectionBlogsSection_items
   pagePartial_section__sectionBlogsSection_pinnedItems
+  pagePartial_section__sectionCaseList_text__internalLink_link
   pagePartial_section__sectionDialogueCta_ctas__internalLink_link
   pagePartial_section__sectionImageCardGrid_items__sectionImageCardGridItem_links__internalLink_link
+  pagePartial_section__sectionImageCardGrid_text__internalLink_link
   pagePartial_section__sectionImageText_body__structuredTextBlueText_body__structuredTextButtonsList_buttons__internalLink_link
   pagePartial_section__sectionImageText_body__structuredTextButtonsList_buttons__internalLink_link
   pagePartial_section__sectionInterstitialCta_ctas__internalLink_link
@@ -8440,8 +8469,10 @@ enum PagePartialModelFieldsReferencingBlogPostModel {
 """Linking fields"""
 enum PagePartialModelFieldsReferencingMeetModel {
   pagePartial_section
+  pagePartial_section__sectionCaseList_text__internalLink_link
   pagePartial_section__sectionDialogueCta_ctas__internalLink_link
   pagePartial_section__sectionImageCardGrid_items__sectionImageCardGridItem_links__internalLink_link
+  pagePartial_section__sectionImageCardGrid_text__internalLink_link
   pagePartial_section__sectionImageText_body__structuredTextBlueText_body__structuredTextButtonsList_buttons__internalLink_link
   pagePartial_section__sectionImageText_body__structuredTextButtonsList_buttons__internalLink_link
   pagePartial_section__sectionInterstitialCta_ctas__internalLink_link
@@ -10871,6 +10902,15 @@ type SectionBlogsSectionRecord implements RecordInterface {
   updatedAt: DateTime!
 }
 
+union SectionCaseListModelTextBlocksField = ExternalLinkRecord | InternalLinkRecord
+
+type SectionCaseListModelTextField {
+  blocks: [SectionCaseListModelTextBlocksField!]!
+  inlineBlocks: [String!]!
+  links: [String!]!
+  value: JsonField!
+}
+
 """Block of type 💼 Section Case List (section_case_list)"""
 type SectionCaseListRecord implements RecordInterface {
   _createdAt: DateTime!
@@ -10895,6 +10935,7 @@ type SectionCaseListRecord implements RecordInterface {
   columns: IntType!
   createdAt: DateTime!
   id: ItemId!
+  text: SectionCaseListModelTextField
   title: String
   updatedAt: DateTime!
 }
@@ -11087,6 +11128,15 @@ type SectionImageCardGridItemRecord implements RecordInterface {
   updatedAt: DateTime!
 }
 
+union SectionImageCardGridModelTextBlocksField = ExternalLinkRecord | InternalLinkRecord
+
+type SectionImageCardGridModelTextField {
+  blocks: [SectionImageCardGridModelTextBlocksField!]!
+  inlineBlocks: [String!]!
+  links: [String!]!
+  value: JsonField!
+}
+
 """Block of type Section Image Card Grid (section_image_card_grid)"""
 type SectionImageCardGridRecord implements RecordInterface {
   _createdAt: DateTime!
@@ -11112,6 +11162,7 @@ type SectionImageCardGridRecord implements RecordInterface {
   createdAt: DateTime!
   id: ItemId!
   items: [SectionImageCardGridItemRecord!]!
+  text: SectionImageCardGridModelTextField
   title: String!
   updatedAt: DateTime!
 }
@@ -11506,6 +11557,7 @@ input SeoFilter {
 """Linking fields"""
 enum ServiceModelFieldsReferencingBlogPostModel {
   service_items
+  service_items__sectionCaseList_text__internalLink_link
   service_items__sectionStructuredText_body__structuredTextBlueText_body__structuredTextButtonsList_buttons__internalLink_link
   service_items__sectionStructuredText_body__structuredTextButtonsList_buttons__internalLink_link
   service_items__sectionStructuredText_body__twoColumnBlock_leftItems__structuredText_body__structuredTextButtonsList_buttons__internalLink_link
@@ -11515,6 +11567,7 @@ enum ServiceModelFieldsReferencingBlogPostModel {
 """Linking fields"""
 enum ServiceModelFieldsReferencingMeetModel {
   service_items
+  service_items__sectionCaseList_text__internalLink_link
   service_items__sectionStructuredText_body__structuredTextBlueText_body__structuredTextButtonsList_buttons__internalLink_link
   service_items__sectionStructuredText_body__structuredTextButtonsList_buttons__internalLink_link
   service_items__sectionStructuredText_body__twoColumnBlock_leftItems__structuredText_body__structuredTextButtonsList_buttons__internalLink_link
@@ -13826,13 +13879,41 @@ type UploadVideoField {
   ): String
   muxAssetId: String!
   muxPlaybackId: String!
+
+  """
+  Default poster frame, in seconds into the video. Resolves to the record-level field override when present, otherwise the upload-level default. `null` means Mux's default (middle of the video).
+  """
+  posterTime: Float
   streamingUrl: String!
   thumbhash: String
   thumbnailUrl(
-    """
-    The file extension of the requested image format. Either png, jpg or gif
-    """
+    """The file extension of the requested image. Either jpg, png or gif"""
     format: MuxThumbnailFormatType = jpg
+
+    """
+    Maps to the Mux `time` param: seconds into the video to grab the frame. When omitted, the upload's poster time is auto-injected (not applied to gif)
+    """
+    time: Float
+
+    """Maps to the Mux `width` param: thumbnail width in pixels"""
+    width: Int
+
+    """Maps to the Mux `height` param: thumbnail height in pixels"""
+    height: Int
+
+    """
+    Maps to the Mux `fit_mode` param: how the image fits the given dimensions
+    """
+    fitMode: MuxThumbnailFitMode
+
+    """Maps to the Mux `rotate` param: clockwise rotation in degrees"""
+    rotate: MuxThumbnailRotation
+
+    """Maps to the Mux `flip_v` param: flip the image vertically"""
+    flipV: Boolean
+
+    """Maps to the Mux `flip_h` param: flip the image horizontally"""
+    flipH: Boolean
   ): String!
   title(
     """The locale to use to fetch the field's content"""

--- a/src/components/Blocks/CaseList/CaseList.query.ts
+++ b/src/components/Blocks/CaseList/CaseList.query.ts
@@ -1,4 +1,5 @@
 import { graphql } from "~/utils/graphql";
+import { LinkFragment } from "~/components/Core/AppLink/AppLink.query";
 
 export const CaseListFragment = graphql(`
   fragment CaseListFragment on SectionCaseListRecord {
@@ -18,5 +19,12 @@ export const CaseListFragment = graphql(`
         }
       }
     }
-  }
-`);
+    text {
+      value
+      blocks {
+        ...LinkFragment
+      }
+    }
+  }`,
+  [LinkFragment],
+);

--- a/src/components/Blocks/CaseList/CaseList.vue
+++ b/src/components/Blocks/CaseList/CaseList.vue
@@ -13,6 +13,9 @@
       />
     </li>
   </ul>
+  <div class="cases-list__text" v-if="data.text">
+    <StructuredTextBlock :content="data.text" />
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -59,5 +62,11 @@ const sizes = computed(() => {
 
 .cases-list .link-card {
   height: 100%;
+}
+
+.cases-list__text {
+  margin-top: var(--spacing-medium);
+  margin-inline: auto;
+  text-align: center;
 }
 </style>

--- a/src/components/Blocks/ImageCardGrid/ImageCardGrid.query.ts
+++ b/src/components/Blocks/ImageCardGrid/ImageCardGrid.query.ts
@@ -7,6 +7,12 @@ export const ImageCardGridFragment = graphql(
       title
       backgroundColor
       cardOrientation
+      text {
+        value
+        blocks {
+          ...LinkFragment
+        }
+      }
       items {
         id
         title

--- a/src/components/Blocks/ImageCardGrid/ImageCardGrid.vue
+++ b/src/components/Blocks/ImageCardGrid/ImageCardGrid.vue
@@ -43,6 +43,9 @@
         </div>
       </li>
     </ul>
+    <div class="image-card-grid__text" v-if="data.text">
+      <StructuredTextBlock :content="data.text" />
+    </div>
   </section>
 </template>
 
@@ -127,6 +130,12 @@ const imageSizes = computed(() => {
   right: 0;
   bottom: 0;
   left: 0;
+}
+
+.image-card-grid__text {
+  margin-top: var(--spacing-larger);
+  margin-inline: auto;
+  text-align: center;
 }
 
 @media (min-width: 720px) {

--- a/src/components/structured-text-block/structured-text-block.vue
+++ b/src/components/structured-text-block/structured-text-block.vue
@@ -127,6 +127,17 @@
 
   function renderBlock({ record, key }) {
     switch (record.__typename) {
+      case 'ExternalLinkRecord':
+      case 'InternalLinkRecord': {
+        const isExternal = record.__typename === 'ExternalLinkRecord'
+        return h(AppButton, {
+          key,
+          label: record.title,
+          to: isExternal ? record.url : record.link,
+          external: isExternal,
+          secondary: record.style !== 'primary',
+        })
+      }
       case 'StructuredTextHighlightedListRecord': {
         return h('ul', {
           key,
@@ -306,15 +317,15 @@
     margin-bottom: var(--spacing-small);
   }
 
-  .structured-text p a,
+  .structured-text p a:not(.app-button),
   .structured-text__glossary-ref {
     color: var(--html-blue);
     padding-bottom: .15rem;
     background: transparent linear-gradient(to top, transparent 1px, var(--html-blue) 1px, var(--html-blue) 2px, transparent 2px);
   }
 
-  .structured-text p a:hover,
-  .structured-text p a:focus,
+  .structured-text p a:not(.app-button):hover,
+  .structured-text p a:not(.app-button):focus,
   .structured-text__glossary-ref:hover,
   .structured-text__glossary-ref:focus {
     color: var(--active-blue);

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -1,3 +1,3 @@
-export const datocmsEnvironment = 'fix-minor-ui';
+export const datocmsEnvironment = 'cards-cases-links';
 export const mastodonUrl = 'https://fosstodon.org/@devoorhoede';
 export const datocmsContentApiUrl = 'https://graphql.datocms.com/';


### PR DESCRIPTION
## Add structured text with link blocks to CaseList and ImageCardGrid

### Summary
Adds an optional structured-text field to the **CaseList** and **ImageCardGrid** section blocks.
Inline `InternalLinkRecord` / `ExternalLinkRecord` blocks are rendered as buttons within structured text.

**Other**
- Regenerated `shared/generated/schema.graphql` 
- Bumped `datocmsEnvironment` to `cards-cases-links`.

### Notes
- ⚠️ `datocmsEnvironment` points at the `cards-cases-links` sandbox — confirm this should be promoted before merging.

