### PR TITLE
fix: hardcoded lang on blog and event post

### DIFF
--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -1,7 +1,7 @@
 <template>
   <main
     class="page-blog-post grid"
-    lang="en"
+    :lang="params.language"
   >
     <page-header
       class="page-blog-post__header"

--- a/src/pages/[language]/blog/[slug]/index.vue
+++ b/src/pages/[language]/blog/[slug]/index.vue
@@ -1,7 +1,6 @@
 <template>
   <main
     class="page-blog-post grid"
-    :lang="params.language"
   >
     <page-header
       class="page-blog-post__header"

--- a/src/pages/[language]/events/[slug]/index.vue
+++ b/src/pages/[language]/events/[slug]/index.vue
@@ -2,7 +2,6 @@
   <main>
     <div
       class="page-event-detail grid"
-      :lang="params.language"
     >
       <page-header
         class="page-event-detail__header"

--- a/src/pages/[language]/events/[slug]/index.vue
+++ b/src/pages/[language]/events/[slug]/index.vue
@@ -2,7 +2,7 @@
   <main>
     <div
       class="page-event-detail grid"
-      lang="en"
+      :lang="params.language"
     >
       <page-header
         class="page-event-detail__header"


### PR DESCRIPTION
## What changes were made
Fixed hardcoded `lang="en"` on blog and event detail pages so the `lang` attribute matches the page's actual locale.

Fixes #560 

## How to test or check results
Visit a `/nl/` blog or event page (e.g. http://localhost:3000/nl/blog/vrienden-voorhoede-bas-de-vleeschhouwer/) and confirm the `<main>`/`<div>` `lang` is `nl`, not `en`.

## Checks
- [ ] All content model changes are done through [scripted migrations](../readme.md#scripted-migrations)
- [ ] Appointed PR reviewers
